### PR TITLE
feat: Vercelデプロイ設定を追加 (#43)

### DIFF
--- a/docs/VERCEL_DEPLOYMENT.md
+++ b/docs/VERCEL_DEPLOYMENT.md
@@ -1,0 +1,84 @@
+# Vercelデプロイ手順（Web版フロントエンド）
+
+## 前提条件
+- Vercelアカウントを作成済み
+- GitHubリポジトリとの連携が完了している
+
+## デプロイ手順
+
+### 1. Vercelプロジェクトの作成
+
+1. [Vercel Dashboard](https://vercel.com/dashboard) にアクセス
+2. 「New Project」をクリック
+3. GitHubリポジトリ「Otoriha/Reco_Meshi」を選択
+4. プロジェクト名を設定（例：`reco-meshi-web`）
+
+### 2. ビルド設定
+
+以下の設定を行います：
+
+| 設定項目 | 値 |
+|---------|-----|
+| Framework Preset | Vite |
+| Root Directory | `frontend` |
+| Build Command | `npm run build` |
+| Output Directory | `dist` |
+| Install Command | `npm install` |
+
+### 3. 環境変数の設定
+
+Vercelダッシュボードの「Settings」→「Environment Variables」で以下を設定：
+
+| 変数名 | 説明 | 例 |
+|--------|------|-----|
+| `VITE_API_URL` | バックエンドAPIのURL | `https://api.recomeshi.com/api/v1` |
+| `VITE_APP_URL` | フロントエンドのURL | `https://recomeshi.com` |
+
+**注意事項:**
+- 本番環境のAPI URLは、バックエンドがデプロイされた後に設定してください
+- 開発環境と本番環境で異なる値を設定する場合は、Environment（Production/Preview/Development）ごとに設定可能です
+
+### 4. デプロイの実行
+
+1. 「Deploy」ボタンをクリック
+2. ビルドログを確認し、エラーがないことを確認
+3. デプロイ完了後、提供されたURLでアプリケーションにアクセス
+
+### 5. カスタムドメインの設定（オプション）
+
+1. 「Settings」→「Domains」にアクセス
+2. カスタムドメインを追加
+3. DNSレコードを設定（Vercelが提供する指示に従う）
+
+## 自動デプロイ
+
+GitHubのmainブランチにマージされると自動的にデプロイが実行されます。
+
+### ブランチプレビュー
+- Pull Requestを作成すると、自動的にプレビューデプロイが作成されます
+- PRのコメントにプレビューURLが自動的に追加されます
+
+## トラブルシューティング
+
+### ビルドエラーが発生した場合
+1. ローカルで `npm run build` が成功することを確認
+2. Node.jsのバージョンを確認（package.jsonにenginesフィールドを追加することを推奨）
+3. 環境変数が正しく設定されているか確認
+
+### 404エラーが発生する場合
+- SPAのルーティングが正しく設定されているか確認
+- Vercelは自動的にSPAのルーティングを処理しますが、問題がある場合は`vercel.json`でrewritesを設定
+
+## ローカルでの確認
+
+デプロイ前にローカルで本番ビルドを確認：
+
+```bash
+cd frontend
+npm run build
+npm run preview
+```
+
+## 関連ドキュメント
+- [Vercel Documentation](https://vercel.com/docs)
+- [Vite Deployment Guide](https://vitejs.dev/guide/static-deploy.html#vercel)

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_BASE_URL = import.meta.env.REACT_APP_API_URL || 'http://localhost:3000/api/v1';
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000/api/v1';
 
 export const apiClient = axios.create({
   baseURL: API_BASE_URL,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,4 +8,19 @@ export default defineConfig({
     port: 3001,
     host: '0.0.0.0',
   },
+  build: {
+    outDir: 'dist',
+    sourcemap: true,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          vendor: ['react', 'react-dom', 'react-router-dom'],
+          axios: ['axios'],
+        },
+      },
+    },
+  },
+  define: {
+    'process.env': {},
+  },
 })


### PR DESCRIPTION
## 概要
  Web版フロントエンドのVercelデプロイ設定を行った。

  ### 実装内容
  - 環境変数をVite標準のprefix（`VITE_`）に変更
    - `REACT_APP_API_URL` → `VITE_API_URL`
    - `REACT_APP_APP_URL` → `VITE_APP_URL`
    - `REACT_APP_LIFF_ID` → `VITE_LIFF_ID`
  - Viteビルド設定の最適化
    - コード分割設定（vendor/axiosチャンク）
    - ソースマップ生成

  ### 編集ファイル
  - `.env` - 環境変数名をVite用に変更
  - `frontend/src/api/client.ts`
  - `frontend/vite.config.ts`