### PR TITLE
ユーザー登録実装

### DIFF
--- a/backend/app/controllers/api/v1/users/registrations_controller.rb
+++ b/backend/app/controllers/api/v1/users/registrations_controller.rb
@@ -3,6 +3,9 @@ class Api::V1::Users::RegistrationsController < Devise::RegistrationsController
   respond_to :json
   wrap_parameters false
 
+  # ApplicationControllerのauthenticate_user!をスキップ（新規登録時は認証不要）
+  skip_before_action :authenticate_user!, only: [:create]
+
   before_action :normalize_devise_param_keys, only: [:create]
 
   before_action :configure_sign_up_params, only: [:create]
@@ -25,17 +28,32 @@ class Api::V1::Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def respond_with(resource, _opts = {})
-    if resource.persisted?
-      render json: {
-        status: { code: 200, message: 'Signed up successfully.' },
-        data: UserSerializer.new(resource).serializable_hash[:data][:attributes]
-      }, status: :ok
-    else
-      render json: {
-        status: { message: "User couldn't be created successfully. #{resource.errors.full_messages.to_sentence}" }
-      }, status: :unprocessable_entity
-    end
+  if resource.persisted?
+    # APIモードではsign_inではなく、JWTトークンを手動で生成
+    token = generate_jwt_token(resource)
+    response.set_header('Authorization', "Bearer #{token}")
+    
+    render json: {
+      status: { code: 200, message: 'Signed up successfully.' },
+      data: UserSerializer.new(resource).serializable_hash[:data][:attributes]
+    }, status: :ok
+  else
+    render json: {
+      status: { message: "User couldn't be created successfully. #{resource.errors.full_messages.to_sentence}" }
+    }, status: :unprocessable_entity
   end
+end
+
+# APIモードでJWTトークンを手動生成するためのヘルパーメソッド
+def generate_jwt_token(user)
+  payload = user.jwt_payload.merge({
+    sub: user.id.to_s,
+    jti: SecureRandom.uuid,
+    exp: 1.day.from_now.to_i
+  })
+  
+  JWT.encode(payload, ENV.fetch('DEVISE_JWT_SECRET_KEY', Rails.application.secret_key_base), 'HS256')
+end
 
   def configure_sign_up_params
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])

--- a/backend/app/controllers/api/v1/users/sessions_controller.rb
+++ b/backend/app/controllers/api/v1/users/sessions_controller.rb
@@ -3,6 +3,9 @@ class Api::V1::Users::SessionsController < Devise::SessionsController
   respond_to :json
   wrap_parameters false
 
+  # ApplicationControllerのauthenticate_user!をスキップ（ログイン時は認証不要）
+  skip_before_action :authenticate_user!, only: [:create, :destroy]
+
   before_action :normalize_devise_param_keys, only: [:create]
 
   # カスタム認証（devise-jwtのdispatchは sign_in 呼び出しで発火）

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -2,11 +2,19 @@ class ApplicationController < ActionController::API
   # APIモードのため、protect_from_forgeryを含めない
   # Deviseコントローラー用の設定
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :authenticate_user!
 
   protected
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
     devise_parameter_sanitizer.permit(:account_update, keys: [:name])
+  end
+
+  # 未確認ユーザーのアクセス制御（必要に応じて各コントローラでskip可能）
+  def ensure_confirmed_user!
+    return if !current_user.respond_to?(:confirmed?) || current_user.confirmed?
+
+    render json: { error: 'You have to confirm your email address' }, status: :forbidden
   end
 end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -10,6 +10,6 @@ class User < ApplicationRecord
 
   # JWT payloadの追加クレームを定義（subはdevise-jwtが自動付与）
   def jwt_payload
-    { 'email' => email }
-  end
+  { 'email' => email, 'confirmed' => confirmed_at.present? }
+end
 end


### PR DESCRIPTION
## 概要
  Issue #9 ユーザー登録機能におけるJWT発行機能を実装した。

  ### 実装内容
  - **User model拡張**: JWTペイロードに`confirmed`状態を追加
  - **APIモード対応**: セッション無効化環境でのJWT手動生成機能を実装
  - **認証フロー改善**: 登録・ログイン時の認証スキップ設定を追加

  ### 編集ファイル
  - `backend/app/models/user.rb`
    - `jwt_payload`メソッドに`confirmed`状態を追加
  - `backend/app/controllers/api/v1/users/registrations_controller.rb`
    - APIモード用JWT手動生成機能を実装
    - 認証スキップ設定を追加
  - `backend/app/controllers/api/v1/users/sessions_controller.rb`
    - 認証スキップ設定を追加