### PR TITLE
feature/issue 11 signup web

### DIFF
--- a/backend/app/controllers/api/v1/users/registrations_controller.rb
+++ b/backend/app/controllers/api/v1/users/registrations_controller.rb
@@ -25,18 +25,18 @@ class Api::V1::Users::RegistrationsController < Devise::RegistrationsController
         response.set_header('Authorization', "Bearer #{token}")
         
         render json: {
-          status: { code: 200, message: 'Signed up successfully.' },
+          status: { code: 200, message: '新規登録が完了しました。' },
           data: UserSerializer.new(resource).serializable_hash[:data][:attributes]
         }, status: :ok
       else
         # Confirmable enabled: No auto sign-in, no JWT, just success message
         render json: {
-          status: { code: 200, message: 'A confirmation email has been sent to your email address.' }
+          status: { code: 200, message: '確認メールを送信しました。メールをご確認ください。' }
         }, status: :ok
       end
     else
       render json: {
-        status: { message: "User couldn't be created successfully. #{resource.errors.full_messages.to_sentence}" }
+        status: { message: "ユーザー登録に失敗しました。#{resource.errors.full_messages.to_sentence}" }
       }, status: :unprocessable_entity
     end
   end

--- a/backend/app/controllers/api/v1/users/registrations_controller.rb
+++ b/backend/app/controllers/api/v1/users/registrations_controller.rb
@@ -11,6 +11,36 @@ class Api::V1::Users::RegistrationsController < Devise::RegistrationsController
   before_action :configure_sign_up_params, only: [:create]
   before_action :configure_account_update_params, only: [:update]
 
+  # Override create to control auto sign-in behavior
+  def create
+    build_resource(sign_up_params)
+
+    if resource.save
+      if ENV['CONFIRMABLE_ENABLED'] != 'true'
+        # Confirmable disabled: Auto sign-in and issue JWT
+        sign_in(resource_name, resource, store: false)
+        
+        # Manual JWT generation since we excluded signup from dispatch_requests
+        token = generate_jwt_token(resource)
+        response.set_header('Authorization', "Bearer #{token}")
+        
+        render json: {
+          status: { code: 200, message: 'Signed up successfully.' },
+          data: UserSerializer.new(resource).serializable_hash[:data][:attributes]
+        }, status: :ok
+      else
+        # Confirmable enabled: No auto sign-in, no JWT, just success message
+        render json: {
+          status: { code: 200, message: 'A confirmation email has been sent to your email address.' }
+        }, status: :ok
+      end
+    else
+      render json: {
+        status: { message: "User couldn't be created successfully. #{resource.errors.full_messages.to_sentence}" }
+      }, status: :unprocessable_entity
+    end
+  end
+
   private
 
   # テスト/クライアント互換のため、params[:user] を Devise の resource_name にマップ
@@ -26,23 +56,6 @@ class Api::V1::Users::RegistrationsController < Devise::RegistrationsController
     source = params[resource_name] || params[:user] || ActionController::Parameters.new
     source.permit(:name, :email, :password, :password_confirmation)
   end
-
-  def respond_with(resource, _opts = {})
-  if resource.persisted?
-    # APIモードではsign_inではなく、JWTトークンを手動で生成
-    token = generate_jwt_token(resource)
-    response.set_header('Authorization', "Bearer #{token}")
-    
-    render json: {
-      status: { code: 200, message: 'Signed up successfully.' },
-      data: UserSerializer.new(resource).serializable_hash[:data][:attributes]
-    }, status: :ok
-  else
-    render json: {
-      status: { message: "User couldn't be created successfully. #{resource.errors.full_messages.to_sentence}" }
-    }, status: :unprocessable_entity
-  end
-end
 
 # APIモードでJWTトークンを手動生成するためのヘルパーメソッド
 def generate_jwt_token(user)

--- a/backend/app/controllers/api/v1/users/sessions_controller.rb
+++ b/backend/app/controllers/api/v1/users/sessions_controller.rb
@@ -21,10 +21,10 @@ class Api::V1::Users::SessionsController < Devise::SessionsController
         sign_in(resource_name, resource, store: false)
         respond_with(resource)
       else
-        render json: { error: 'You have to confirm your email address' }, status: :unauthorized
+        render json: { error: 'メールアドレスの確認が必要です' }, status: :unauthorized
       end
     else
-      render json: { error: 'Invalid Email or password' }, status: :unauthorized
+      render json: { error: 'メールアドレスまたはパスワードが正しくありません' }, status: :unauthorized
     end
   end
 
@@ -46,7 +46,7 @@ class Api::V1::Users::SessionsController < Devise::SessionsController
 
   def respond_with(resource, _opts = {})
     render json: {
-      status: { code: 200, message: 'Logged in successfully.' },
+      status: { code: 200, message: 'ログインしました。' },
       data: UserSerializer.new(resource).serializable_hash[:data][:attributes]
     }, status: :ok
   end
@@ -57,7 +57,7 @@ class Api::V1::Users::SessionsController < Devise::SessionsController
     if token.blank?
       render json: {
         status: 401,
-        message: "Couldn't find an active session."
+        message: "アクティブなセッションが見つかりません。"
       }, status: :unauthorized
       return
     end
@@ -81,12 +81,12 @@ class Api::V1::Users::SessionsController < Devise::SessionsController
 
       render json: {
         status: 200,
-        message: "Logged out successfully."
+        message: "ログアウトしました。"
       }, status: :ok
     rescue JWT::DecodeError
       render json: {
         status: 401,
-        message: "Invalid token."
+        message: "無効なトークンです。"
       }, status: :unauthorized
     end
   end

--- a/backend/app/controllers/api/v1/users/sessions_controller.rb
+++ b/backend/app/controllers/api/v1/users/sessions_controller.rb
@@ -15,7 +15,8 @@ class Api::V1::Users::SessionsController < Devise::SessionsController
     self.resource = User.find_for_database_authentication(email: sign_in_params[:email])
 
     if resource&.valid_password?(sign_in_params[:password])
-      if !resource.respond_to?(:confirmed?) || resource.confirmed?
+      # Check email confirmation only if CONFIRMABLE_ENABLED is true
+      if ENV['CONFIRMABLE_ENABLED'] != 'true' || !resource.respond_to?(:confirmed?) || resource.confirmed?
         # APIモードではセッションを書かない
         sign_in(resource_name, resource, store: false)
         respond_with(resource)

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,16 +1,28 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable,
-         :jwt_authenticatable, jwt_revocation_strategy: JwtDenylist
-  # Note: :confirmable will be re-enabled in Issue #58 with proper email configuration
+  
+  # Dynamically configure devise modules based on environment variable
+  devise_modules = [
+    :database_authenticatable, :registerable,
+    :recoverable, :rememberable, :validatable,
+    :jwt_authenticatable
+  ]
+  devise_modules << :confirmable if ENV['CONFIRMABLE_ENABLED'] == 'true'
+  
+  devise(*devise_modules, jwt_revocation_strategy: JwtDenylist)
 
   # Validations (emailはvalidatableモジュールに委譲)
   validates :name, presence: true, length: { maximum: 50 }
 
   # JWT payloadの追加クレームを定義（subはdevise-jwtが自動付与）
   def jwt_payload
-    { 'email' => email, 'confirmed' => true } # Always true until Issue #58 implements email confirmation
+    is_confirmed = if ENV['CONFIRMABLE_ENABLED'] == 'true'
+                     confirmed_at.present?
+                   else
+                     true
+                   end
+
+    { 'email' => email, 'confirmed' => is_confirmed }
   end
 end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -2,14 +2,15 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable, :confirmable,
+         :recoverable, :rememberable, :validatable,
          :jwt_authenticatable, jwt_revocation_strategy: JwtDenylist
+  # Note: :confirmable will be re-enabled in Issue #58 with proper email configuration
 
   # Validations (emailはvalidatableモジュールに委譲)
   validates :name, presence: true, length: { maximum: 50 }
 
   # JWT payloadの追加クレームを定義（subはdevise-jwtが自動付与）
   def jwt_payload
-  { 'email' => email, 'confirmed' => confirmed_at.present? }
-end
+    { 'email' => email, 'confirmed' => true } # Always true until Issue #58 implements email confirmation
+  end
 end

--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -43,6 +43,6 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
       headers: :any,
       methods: [:get, :post, :put, :patch, :delete, :options, :head],
       credentials: true,
-      expose: ["X-Total-Count", "X-Page", "X-Per-Page"] # 必要に応じてカスタムヘッダーを公開
+      expose: ["Authorization", "X-Total-Count", "X-Page", "X-Per-Page"] # フロントからAuthorizationヘッダーを参照可能に
   end
 end

--- a/backend/config/initializers/devise.rb
+++ b/backend/config/initializers/devise.rb
@@ -323,8 +323,8 @@ Devise.setup do |config|
     jwt.secret = ENV.fetch('DEVISE_JWT_SECRET_KEY', Rails.application.secret_key_base)
     jwt.dispatch_requests = [
       ['POST', %r{^/api/v1/auth/login$}],
-      ['POST', %r{^/api/v1/auth/signup$}],
       ['POST', %r{^/api/v1/auth/refresh$}]
+      # NOTE: /auth/signup is excluded to allow manual JWT control based on CONFIRMABLE_ENABLED
     ]
     # Revocation is handled manually in SessionsController#respond_to_on_destroy
     # ここでミドルウェアの自動revocationを無効化（絶対にマッチしないパスに設定）

--- a/backend/spec/requests/api/v1/jwt_authentication_spec.rb
+++ b/backend/spec/requests/api/v1/jwt_authentication_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe "JWT Authentication", type: :request do
         delete "/api/v1/auth/logout", headers: { 'Authorization' => @token }, as: :json
         
         expect(response).to have_http_status(:ok)
-        expect(JSON.parse(response.body)['message']).to eq('Logged out successfully.')
+        expect(JSON.parse(response.body)['message']).to eq('ログアウトしました。')
       end
 
       it "ログアウト後、トークンがブラックリストに追加される" do
@@ -192,7 +192,7 @@ RSpec.describe "JWT Authentication", type: :request do
         delete "/api/v1/auth/logout", as: :json
         
         expect(response).to have_http_status(:unauthorized)
-        expect(JSON.parse(response.body)['message']).to eq("Couldn't find an active session.")
+        expect(JSON.parse(response.body)['message']).to eq("アクティブなセッションが見つかりません。")
       end
 
       it "無効なトークンではログアウトできない" do
@@ -202,7 +202,7 @@ RSpec.describe "JWT Authentication", type: :request do
         delete "/api/v1/auth/logout", headers: { 'Authorization' => invalid_header }, as: :json
 
         expect(response).to have_http_status(:unauthorized)
-        expect(JSON.parse(response.body)['message']).to eq('Invalid token.')
+        expect(JSON.parse(response.body)['message']).to eq('無効なトークンです。')
       end
     end
   end

--- a/backend/spec/requests/api/v1/users/registrations_spec.rb
+++ b/backend/spec/requests/api/v1/users/registrations_spec.rb
@@ -31,16 +31,16 @@ RSpec.describe "Api::V1::Users::Registrations", type: :request do
         
         expect(response).to have_http_status(:ok)
         json = JSON.parse(response.body)
-        expect(json['status']['message']).to eq('Signed up successfully.')
+        expect(json['status']['message']).to eq('新規登録が完了しました。')
       end
 
-      it "確認メールが送信される" do
+      it "確認メールは送信されない（CONFIRMABLE_ENABLED=false）" do
         expect {
           post "/api/v1/auth/signup", params: valid_params, as: :json
-        }.to change { ActionMailer::Base.deliveries.count }.by(1)
+        }.not_to change { ActionMailer::Base.deliveries.count }
       end
 
-      it "新規登録時にJWTトークンが発行され、confirmed=falseが含まれる" do
+      it "新規登録時にJWTトークンが発行され、confirmed=trueが含まれる（CONFIRMABLE_ENABLED=false）" do
         post "/api/v1/auth/signup", params: valid_params, as: :json
 
         expect(response).to have_http_status(:ok)
@@ -50,11 +50,7 @@ RSpec.describe "Api::V1::Users::Registrations", type: :request do
 
         payload = JWT.decode(token.split(' ').last, ENV['DEVISE_JWT_SECRET_KEY'], false).first
         expect(payload['email']).to eq('test@example.com')
-        expect(payload['confirmed']).to eq(false)
-
-        mail = ActionMailer::Base.deliveries.last
-        expect(mail.to).to eq(["test@example.com"])
-        expect(mail.subject).to include("Confirmation instructions")
+        expect(payload['confirmed']).to eq(true) # CONFIRMABLE_ENABLED=false なので true
       end
     end
 
@@ -79,6 +75,160 @@ RSpec.describe "Api::V1::Users::Registrations", type: :request do
         expect(response).to have_http_status(:unprocessable_entity)
         json = JSON.parse(response.body)
         expect(json['status']['message']).to include("Email has already been taken")
+      end
+    end
+  end
+
+  # Environment-specific behavior tests
+  describe "CONFIRMABLE_ENABLED environment variable behavior" do
+    let(:valid_params) do
+      {
+        user: {
+          name: "テストユーザー",
+          email: "env_test@example.com",
+          password: "password123",
+          password_confirmation: "password123"
+        }
+      }
+    end
+
+    context "when CONFIRMABLE_ENABLED=false" do
+      around do |example|
+        original_value = ENV['CONFIRMABLE_ENABLED']
+        ENV['CONFIRMABLE_ENABLED'] = 'false'
+        # Reload User class to apply new devise configuration
+        Rails.application.reloader.reload!
+        example.run
+        ENV['CONFIRMABLE_ENABLED'] = original_value
+        Rails.application.reloader.reload!
+      end
+
+      it "signup時にJWTトークンが発行され、confirmed=trueが含まれる" do
+        post "/api/v1/auth/signup", params: valid_params, as: :json
+
+        expect(response).to have_http_status(:ok)
+        
+        # Check response message
+        json = JSON.parse(response.body)
+        expect(json['status']['message']).to eq('新規登録が完了しました。')
+        expect(json['data']).to be_present
+        expect(json['data']['name']).to eq('テストユーザー')
+        expect(json['data']['email']).to eq('env_test@example.com')
+
+        # Check JWT token in Authorization header
+        token = response.headers['Authorization']
+        expect(token).to be_present
+        expect(token).to match(/^Bearer /)
+
+        # Decode and verify JWT payload
+        payload = JWT.decode(token.split(' ').last, ENV['DEVISE_JWT_SECRET_KEY'], false).first
+        expect(payload['email']).to eq('env_test@example.com')
+        expect(payload['confirmed']).to eq(true) # Should be true when confirmable disabled
+      end
+
+      it "確認メールは送信されない" do
+        expect {
+          post "/api/v1/auth/signup", params: valid_params, as: :json
+        }.not_to change { ActionMailer::Base.deliveries.count }
+      end
+
+      it "作成したユーザーでそのままログインできる" do
+        # First, signup
+        post "/api/v1/auth/signup", params: valid_params, as: :json
+        expect(response).to have_http_status(:ok)
+
+        # Then, try to login with the same credentials
+        login_params = {
+          user: {
+            email: "env_test@example.com",
+            password: "password123"
+          }
+        }
+
+        post "/api/v1/auth/login", params: login_params, as: :json
+        expect(response).to have_http_status(:ok)
+        
+        json = JSON.parse(response.body)
+        expect(json['status']['message']).to eq('ログインしました。')
+        expect(json['data']['email']).to eq('env_test@example.com')
+      end
+    end
+
+    context "when CONFIRMABLE_ENABLED=true" do
+      around do |example|
+        original_value = ENV['CONFIRMABLE_ENABLED']
+        ENV['CONFIRMABLE_ENABLED'] = 'true'
+        # Reload User class to apply new devise configuration
+        Rails.application.reloader.reload!
+        example.run
+        ENV['CONFIRMABLE_ENABLED'] = original_value
+        Rails.application.reloader.reload!
+      end
+
+      it "signup時にJWTトークンが発行されず、確認メール送信メッセージが返る" do
+        post "/api/v1/auth/signup", params: valid_params, as: :json
+
+        expect(response).to have_http_status(:ok)
+        
+        # Check response message
+        json = JSON.parse(response.body)
+        expect(json['status']['message']).to eq('確認メールを送信しました。メールをご確認ください。')
+        expect(json['data']).to be_nil # No user data returned
+
+        # Check no JWT token in Authorization header
+        token = response.headers['Authorization']
+        expect(token).to be_blank
+      end
+
+      it "確認メールは送信されない（将来実装）" do
+        expect {
+          post "/api/v1/auth/signup", params: valid_params, as: :json
+        }.not_to change { ActionMailer::Base.deliveries.count }
+      end
+
+      it "未確認ユーザーはログインできない（401）" do
+        # First, signup
+        post "/api/v1/auth/signup", params: valid_params, as: :json
+        expect(response).to have_http_status(:ok)
+
+        # Then, try to login without email confirmation
+        login_params = {
+          user: {
+            email: "env_test@example.com",
+            password: "password123"
+          }
+        }
+
+        post "/api/v1/auth/login", params: login_params, as: :json
+        expect(response).to have_http_status(:unauthorized)
+        
+        json = JSON.parse(response.body)
+        expect(json['error']).to eq('メールアドレスの確認が必要です')
+      end
+
+      it "確認後のユーザーはログインできる" do
+        # First, signup
+        post "/api/v1/auth/signup", params: valid_params, as: :json
+        expect(response).to have_http_status(:ok)
+
+        # Manually confirm the user (simulating email confirmation)
+        user = User.find_by(email: "env_test@example.com")
+        user.update(confirmed_at: Time.current)
+
+        # Then, try to login after confirmation
+        login_params = {
+          user: {
+            email: "env_test@example.com",
+            password: "password123"
+          }
+        }
+
+        post "/api/v1/auth/login", params: login_params, as: :json
+        expect(response).to have_http_status(:ok)
+        
+        json = JSON.parse(response.body)
+        expect(json['status']['message']).to eq('ログインしました。')
+        expect(json['data']['email']).to eq('env_test@example.com')
       end
     end
   end

--- a/backend/spec/requests/api/v1/users/sessions_spec.rb
+++ b/backend/spec/requests/api/v1/users/sessions_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Api::V1::Users::Sessions", type: :request do
         
         expect(response).to have_http_status(:ok)
         json = JSON.parse(response.body)
-        expect(json['status']['message']).to eq('Logged in successfully.')
+        expect(json['status']['message']).to eq('ログインしました。')
         expect(json['data']['email']).to eq(user.email)
       end
 
@@ -42,8 +42,8 @@ RSpec.describe "Api::V1::Users::Sessions", type: :request do
       end
     end
 
-    context "未確認ユーザーがログインを試みる場合" do
-      it "ログインに失敗する（401）" do
+    context "未確認ユーザーがログインを試みる場合（CONFIRMABLE_ENABLED=false）" do
+      it "ログインに成功する（200）" do
         credentials = {
           user: {
             email: unconfirmed_user.email,
@@ -53,9 +53,9 @@ RSpec.describe "Api::V1::Users::Sessions", type: :request do
         
         post "/api/v1/auth/login", params: credentials, as: :json
         
-        expect(response).to have_http_status(:unauthorized)
+        expect(response).to have_http_status(:ok)
         json = JSON.parse(response.body)
-        expect(json['error']).to include("You have to confirm your email address")
+        expect(json['status']['message']).to eq('ログインしました。')
       end
     end
 
@@ -65,7 +65,7 @@ RSpec.describe "Api::V1::Users::Sessions", type: :request do
         
         expect(response).to have_http_status(:unauthorized)
         json = JSON.parse(response.body)
-        expect(json['error']).to include("Invalid Email or password")
+        expect(json['error']).to include("メールアドレスまたはパスワードが正しくありません")
       end
     end
 
@@ -82,7 +82,7 @@ RSpec.describe "Api::V1::Users::Sessions", type: :request do
         
         expect(response).to have_http_status(:unauthorized)
         json = JSON.parse(response.body)
-        expect(json['error']).to include("Invalid Email or password")
+        expect(json['error']).to include("メールアドレスまたはパスワードが正しくありません")
       end
     end
   end
@@ -105,7 +105,7 @@ RSpec.describe "Api::V1::Users::Sessions", type: :request do
 
         expect(response).to have_http_status(:ok)
         json = JSON.parse(response.body)
-        expect(json['message']).to eq('Logged out successfully.')
+        expect(json['message']).to eq('ログアウトしました。')
 
         # トークンがブラックリストに追加されていることを確認
         jti = JWT.decode(token.split(' ').last, ENV['DEVISE_JWT_SECRET_KEY'], false).first['jti']

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,25 +1,42 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import Dashboard from './pages/Dashboard/Dashboard'
 import Login from './pages/Auth/Login'
 import Signup from './pages/Auth/Signup'
+import { isAuthenticated, logout } from './api/auth'
 
 type AuthMode = 'login' | 'signup';
+
+const isConfirmableEnabled = import.meta.env.VITE_CONFIRMABLE_ENABLED === 'true';
 
 function App() {
   const [isLoggedIn, setIsLoggedIn] = useState(false)
   const [authMode, setAuthMode] = useState<AuthMode>('login')
 
+  // 初期化時にトークンの存在をチェック
+  useEffect(() => {
+    setIsLoggedIn(isAuthenticated());
+  }, []);
+
   const handleSwitchToLogin = () => setAuthMode('login')
   const handleSwitchToSignup = () => setAuthMode('signup')
   
   const handleSignupSuccess = () => {
-    // 新規登録成功時の処理（必要に応じて追加）
+    // 確認メール無効時は自動ログイン状態に
+    if (!isConfirmableEnabled) {
+      setIsLoggedIn(true);
+    }
     console.log('Sign up successful')
   }
 
-  const handleLogout = () => {
-    setIsLoggedIn(false)
-    setAuthMode('login')
+  const handleLogout = async () => {
+    try {
+      await logout();
+    } catch (error) {
+      console.error('Logout error:', error);
+    } finally {
+      setIsLoggedIn(false);
+      setAuthMode('login');
+    }
   }
 
   return (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,26 @@
 import { useState } from 'react'
 import Dashboard from './pages/Dashboard/Dashboard'
 import Login from './pages/Auth/Login'
+import Signup from './pages/Auth/Signup'
+
+type AuthMode = 'login' | 'signup';
 
 function App() {
   const [isLoggedIn, setIsLoggedIn] = useState(false)
+  const [authMode, setAuthMode] = useState<AuthMode>('login')
+
+  const handleSwitchToLogin = () => setAuthMode('login')
+  const handleSwitchToSignup = () => setAuthMode('signup')
+  
+  const handleSignupSuccess = () => {
+    // 新規登録成功時の処理（必要に応じて追加）
+    console.log('Sign up successful')
+  }
+
+  const handleLogout = () => {
+    setIsLoggedIn(false)
+    setAuthMode('login')
+  }
 
   return (
     <div className="min-h-screen bg-gray-100">
@@ -15,7 +32,7 @@ function App() {
             </h1>
             <nav className="space-x-4">
               <button 
-                onClick={() => setIsLoggedIn(!isLoggedIn)}
+                onClick={() => isLoggedIn ? handleLogout() : setIsLoggedIn(true)}
                 className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors"
               >
                 {isLoggedIn ? 'ログアウト' : 'ログイン'}
@@ -26,7 +43,16 @@ function App() {
       </header>
       
       <main>
-        {isLoggedIn ? <Dashboard /> : <Login />}
+        {isLoggedIn ? (
+          <Dashboard />
+        ) : authMode === 'login' ? (
+          <Login onSwitchToSignup={handleSwitchToSignup} />
+        ) : (
+          <Signup 
+            onSwitchToLogin={handleSwitchToLogin}
+            onSignupSuccess={handleSignupSuccess}
+          />
+        )}
       </main>
     </div>
   )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,7 +49,7 @@ function App() {
             </h1>
             <nav className="space-x-4">
               <button 
-                onClick={() => isLoggedIn ? handleLogout() : setIsLoggedIn(true)}
+                onClick={() => isLoggedIn ? handleLogout() : setAuthMode('login')}
                 className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors"
               >
                 {isLoggedIn ? 'ログアウト' : 'ログイン'}

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -27,7 +27,7 @@ export interface AuthResponse {
     code: number;
     message: string;
   };
-  data: UserData;
+  data?: UserData; // Optional because confirmable enabled returns no data
 }
 
 export interface AuthError {
@@ -37,7 +37,7 @@ export interface AuthError {
   error?: string;
 }
 
-export const signup = async (data: SignupData): Promise<UserData> => {
+export const signup = async (data: SignupData): Promise<UserData | void> => {
   try {
     const response = await apiClient.post<AuthResponse>('/auth/signup', {
       user: {
@@ -57,6 +57,7 @@ export const signup = async (data: SignupData): Promise<UserData> => {
     }
     // 確認メール有効時はトークンを保存せず、メール確認後にログインしてもらう
 
+    // Return user data if available, otherwise void for confirmable enabled case
     return response.data.data;
   } catch (error: any) {
     if (error.response?.data) {
@@ -89,6 +90,10 @@ export const login = async (data: LoginData): Promise<UserData> => {
       // "Bearer "を除去してlocalStorageに保存
       const token = authHeader.replace('Bearer ', '');
       localStorage.setItem('authToken', token);
+    }
+
+    if (!response.data.data) {
+      throw new Error('ログイン情報の取得に失敗しました。');
     }
 
     return response.data.data;

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,0 +1,127 @@
+import { apiClient } from './client';
+
+export interface SignupData {
+  name: string;
+  email: string;
+  password: string;
+  passwordConfirmation: string;
+}
+
+export interface LoginData {
+  email: string;
+  password: string;
+}
+
+export interface UserData {
+  id: number;
+  name: string;
+  email: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AuthResponse {
+  status: {
+    code: number;
+    message: string;
+  };
+  data: UserData;
+}
+
+export interface AuthError {
+  status?: {
+    message: string;
+  };
+  error?: string;
+}
+
+export const signup = async (data: SignupData): Promise<UserData> => {
+  try {
+    const response = await apiClient.post<AuthResponse>('/auth/signup', {
+      user: {
+        name: data.name,
+        email: data.email,
+        password: data.password,
+        password_confirmation: data.passwordConfirmation,
+      },
+    });
+
+    // AuthorizationヘッダーからJWTトークンを取得
+    const authHeader = response.headers['authorization'];
+    if (authHeader) {
+      // "Bearer "を除去してlocalStorageに保存
+      const token = authHeader.replace('Bearer ', '');
+      localStorage.setItem('authToken', token);
+    }
+
+    return response.data.data;
+  } catch (error: any) {
+    if (error.response?.data) {
+      const errorData = error.response.data as AuthError;
+      // サインアップエラー（422）はstatus.messageに詳細メッセージが含まれる
+      if (errorData.status?.message) {
+        throw new Error(errorData.status.message);
+      }
+      // その他のエラー
+      if (errorData.error) {
+        throw new Error(errorData.error);
+      }
+    }
+    throw new Error('サインアップに失敗しました。もう一度お試しください。');
+  }
+};
+
+export const login = async (data: LoginData): Promise<UserData> => {
+  try {
+    const response = await apiClient.post<AuthResponse>('/auth/login', {
+      user: {
+        email: data.email,
+        password: data.password,
+      },
+    });
+
+    // AuthorizationヘッダーからJWTトークンを取得
+    const authHeader = response.headers['authorization'];
+    if (authHeader) {
+      // "Bearer "を除去してlocalStorageに保存
+      const token = authHeader.replace('Bearer ', '');
+      localStorage.setItem('authToken', token);
+    }
+
+    return response.data.data;
+  } catch (error: any) {
+    if (error.response?.data) {
+      const errorData = error.response.data as AuthError;
+      // ログインエラー（401）はerrorフィールドに含まれる
+      if (errorData.error) {
+        throw new Error(errorData.error);
+      }
+      if (errorData.status?.message) {
+        throw new Error(errorData.status.message);
+      }
+    }
+    throw new Error('ログインに失敗しました。メールアドレスとパスワードを確認してください。');
+  }
+};
+
+export const logout = async (): Promise<void> => {
+  try {
+    await apiClient.delete('/auth/logout');
+  } catch (error) {
+    // ログアウトはトークンクリアが主目的なので、APIエラーは無視
+    console.warn('Logout API error:', error);
+  } finally {
+    // 必ずlocalStorageをクリア
+    localStorage.removeItem('authToken');
+  }
+};
+
+// トークンの存在チェック
+export const isAuthenticated = (): boolean => {
+  return !!localStorage.getItem('authToken');
+};
+
+// 認証状態をクリア
+export const clearAuth = (): void => {
+  localStorage.removeItem('authToken');
+};

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,5 +1,7 @@
 import { apiClient } from './client';
 
+const isConfirmableEnabled = import.meta.env.VITE_CONFIRMABLE_ENABLED === 'true';
+
 export interface SignupData {
   name: string;
   email: string;
@@ -48,11 +50,12 @@ export const signup = async (data: SignupData): Promise<UserData> => {
 
     // AuthorizationヘッダーからJWTトークンを取得
     const authHeader = response.headers['authorization'];
-    if (authHeader) {
-      // "Bearer "を除去してlocalStorageに保存
+    if (authHeader && !isConfirmableEnabled) {
+      // 確認メール無効時のみトークンを保存（自動ログイン）
       const token = authHeader.replace('Bearer ', '');
       localStorage.setItem('authToken', token);
     }
+    // 確認メール有効時はトークンを保存せず、メール確認後にログインしてもらう
 
     return response.data.data;
   } catch (error: any) {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -22,4 +22,22 @@ apiClient.interceptors.request.use(
   }
 );
 
+// Response interceptor to handle 401 errors
+apiClient.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  (error) => {
+    if (error.response?.status === 401) {
+      // Clear invalid token on 401 error
+      localStorage.removeItem('authToken');
+      
+      // Optional: Redirect to login or trigger logout
+      // This can be customized based on app requirements
+      console.warn('Authentication failed. Token cleared.');
+    }
+    return Promise.reject(error);
+  }
+);
+
 export default apiClient;

--- a/frontend/src/pages/Auth/Login.tsx
+++ b/frontend/src/pages/Auth/Login.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 
-const Login: React.FC = () => {
+type LoginProps = {
+  onSwitchToSignup?: () => void;
+};
+
+const Login: React.FC<LoginProps> = ({ onSwitchToSignup }) => {
   return (
     <div className="min-h-screen bg-gray-50 flex items-center justify-center">
       <div className="max-w-md w-full bg-white rounded-lg shadow p-6">
@@ -33,6 +37,16 @@ const Login: React.FC = () => {
             ログイン
           </button>
         </form>
+        <div className="mt-4 text-center text-sm text-gray-600">
+          アカウントをお持ちでない方は{' '}
+          <button
+            type="button"
+            onClick={onSwitchToSignup}
+            className="text-blue-600 hover:underline"
+          >
+            新規登録はこちら
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/Auth/Signup.tsx
+++ b/frontend/src/pages/Auth/Signup.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import { signup } from '../../api/auth';
 
+const isConfirmableEnabled = import.meta.env.VITE_CONFIRMABLE_ENABLED === 'true';
+
 type SignupProps = {
   onSwitchToLogin?: () => void;
   onSignupSuccess?: () => void;
@@ -119,14 +121,25 @@ const Signup: React.FC<SignupProps> = ({ onSwitchToLogin, onSignupSuccess }) => 
         passwordConfirmation: formData.passwordConfirmation,
       });
 
-      // 成功メッセージを表示
-      setSuccessMessage('登録完了しました。ログイン画面に移動します。');
-      
-      // 2秒後にログイン画面へ遷移
-      setTimeout(() => {
-        onSignupSuccess?.();
-        onSwitchToLogin?.();
-      }, 2000);
+      if (isConfirmableEnabled) {
+        // 確認メール有効時：確認メールメッセージ表示、ログイン画面へ遷移
+        setSuccessMessage('登録完了しました。確認メールをご確認ください。');
+        
+        // 2秒後にログイン画面へ遷移
+        setTimeout(() => {
+          onSignupSuccess?.();
+          onSwitchToLogin?.();
+        }, 2000);
+      } else {
+        // 確認メール無効時：自動ログイン（トークンは既にauth.tsで保存済み）
+        setSuccessMessage('登録完了しました。自動的にログインします。');
+        
+        // 1秒後に自動ログイン状態へ遷移
+        setTimeout(() => {
+          onSignupSuccess?.();
+          // 親コンポーネントでログイン状態が更新される
+        }, 1000);
+      }
 
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : '登録に失敗しました。';

--- a/frontend/src/pages/Auth/Signup.tsx
+++ b/frontend/src/pages/Auth/Signup.tsx
@@ -120,7 +120,7 @@ const Signup: React.FC<SignupProps> = ({ onSwitchToLogin, onSignupSuccess }) => 
       });
 
       // 成功メッセージを表示
-      setSuccessMessage('登録完了しました。確認メールをご確認ください。');
+      setSuccessMessage('登録完了しました。ログイン画面に移動します。');
       
       // 2秒後にログイン画面へ遷移
       setTimeout(() => {

--- a/frontend/src/pages/Auth/Signup.tsx
+++ b/frontend/src/pages/Auth/Signup.tsx
@@ -1,0 +1,276 @@
+import React, { useState } from 'react';
+import { signup } from '../../api/auth';
+
+type SignupProps = {
+  onSwitchToLogin?: () => void;
+  onSignupSuccess?: () => void;
+};
+
+interface FormData {
+  name: string;
+  email: string;
+  password: string;
+  passwordConfirmation: string;
+}
+
+interface FormErrors {
+  name?: string;
+  email?: string;
+  password?: string;
+  passwordConfirmation?: string;
+  general?: string;
+}
+
+const Signup: React.FC<SignupProps> = ({ onSwitchToLogin, onSignupSuccess }) => {
+  const [formData, setFormData] = useState<FormData>({
+    name: '',
+    email: '',
+    password: '',
+    passwordConfirmation: '',
+  });
+
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [isLoading, setIsLoading] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string>('');
+
+  // バリデーション関数
+  const validateField = (name: keyof FormData, value: string): string | undefined => {
+    switch (name) {
+      case 'name':
+        if (!value.trim()) return '名前は必須です。';
+        if (value.trim().length < 2) return '名前は2文字以上で入力してください。';
+        if (value.trim().length > 50) return '名前は50文字以内で入力してください。';
+        break;
+      case 'email':
+        if (!value.trim()) return 'メールアドレスは必須です。';
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!emailRegex.test(value)) return '正しいメールアドレスを入力してください。';
+        break;
+      case 'password':
+        if (!value) return 'パスワードは必須です。';
+        if (value.length < 6) return 'パスワードは6文字以上で入力してください。';
+        break;
+      case 'passwordConfirmation':
+        if (!value) return 'パスワード確認は必須です。';
+        if (value !== formData.password) return 'パスワードと一致しません。';
+        break;
+      default:
+        break;
+    }
+    return undefined;
+  };
+
+  // フォームデータ更新
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({ ...prev, [name]: value }));
+    
+    // リアルタイムバリデーション（エラーがある場合のみ）
+    if (errors[name as keyof FormErrors]) {
+      const error = validateField(name as keyof FormData, value);
+      setErrors(prev => ({ ...prev, [name]: error }));
+    }
+  };
+
+  // フィールドのblur時バリデーション
+  const handleInputBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    const error = validateField(name as keyof FormData, value);
+    setErrors(prev => ({ ...prev, [name]: error }));
+  };
+
+  // 全フィールドバリデーション
+  const validateForm = (): boolean => {
+    const newErrors: FormErrors = {};
+    let isValid = true;
+
+    (Object.keys(formData) as Array<keyof FormData>).forEach(key => {
+      const error = validateField(key, formData[key]);
+      if (error) {
+        newErrors[key] = error;
+        isValid = false;
+      }
+    });
+
+    setErrors(newErrors);
+    return isValid;
+  };
+
+  // フォーム送信
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    // 成功メッセージをクリア
+    setSuccessMessage('');
+    
+    // バリデーション
+    if (!validateForm()) {
+      return;
+    }
+
+    setIsLoading(true);
+    setErrors(prev => ({ ...prev, general: undefined }));
+
+    try {
+      await signup({
+        name: formData.name.trim(),
+        email: formData.email.trim(),
+        password: formData.password,
+        passwordConfirmation: formData.passwordConfirmation,
+      });
+
+      // 成功メッセージを表示
+      setSuccessMessage('登録完了しました。確認メールをご確認ください。');
+      
+      // 2秒後にログイン画面へ遷移
+      setTimeout(() => {
+        onSignupSuccess?.();
+        onSwitchToLogin?.();
+      }, 2000);
+
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : '登録に失敗しました。';
+      setErrors({ general: errorMessage });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="max-w-md w-full bg-white rounded-lg shadow p-6">
+        <h1 className="text-2xl font-bold text-gray-900 mb-6 text-center">
+          新規登録
+        </h1>
+        
+        {/* 成功メッセージ */}
+        {successMessage && (
+          <div className="mb-4 p-3 bg-green-100 border border-green-400 text-green-700 rounded">
+            {successMessage}
+          </div>
+        )}
+
+        {/* 汎用エラーメッセージ */}
+        {errors.general && (
+          <div className="mb-4 p-3 bg-red-100 border border-red-400 text-red-700 rounded">
+            {errors.general}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* 名前 */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              名前
+            </label>
+            <input
+              type="text"
+              name="name"
+              value={formData.name}
+              onChange={handleInputChange}
+              onBlur={handleInputBlur}
+              className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                errors.name ? 'border-red-300' : 'border-gray-300'
+              }`}
+              disabled={isLoading}
+            />
+            {errors.name && (
+              <p className="mt-1 text-sm text-red-600">{errors.name}</p>
+            )}
+          </div>
+
+          {/* メールアドレス */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              メールアドレス
+            </label>
+            <input
+              type="email"
+              name="email"
+              value={formData.email}
+              onChange={handleInputChange}
+              onBlur={handleInputBlur}
+              className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                errors.email ? 'border-red-300' : 'border-gray-300'
+              }`}
+              disabled={isLoading}
+            />
+            {errors.email && (
+              <p className="mt-1 text-sm text-red-600">{errors.email}</p>
+            )}
+          </div>
+
+          {/* パスワード */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              パスワード
+            </label>
+            <input
+              type="password"
+              name="password"
+              value={formData.password}
+              onChange={handleInputChange}
+              onBlur={handleInputBlur}
+              className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                errors.password ? 'border-red-300' : 'border-gray-300'
+              }`}
+              disabled={isLoading}
+            />
+            {errors.password && (
+              <p className="mt-1 text-sm text-red-600">{errors.password}</p>
+            )}
+          </div>
+
+          {/* パスワード確認 */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              パスワード確認
+            </label>
+            <input
+              type="password"
+              name="passwordConfirmation"
+              value={formData.passwordConfirmation}
+              onChange={handleInputChange}
+              onBlur={handleInputBlur}
+              className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                errors.passwordConfirmation ? 'border-red-300' : 'border-gray-300'
+              }`}
+              disabled={isLoading}
+            />
+            {errors.passwordConfirmation && (
+              <p className="mt-1 text-sm text-red-600">{errors.passwordConfirmation}</p>
+            )}
+          </div>
+
+          {/* 送信ボタン */}
+          <button
+            type="submit"
+            disabled={isLoading || !!successMessage}
+            className={`w-full py-2 px-4 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+              isLoading || successMessage
+                ? 'bg-gray-400 cursor-not-allowed'
+                : 'bg-blue-600 hover:bg-blue-700'
+            } text-white`}
+          >
+            {isLoading ? '登録中...' : '新規登録'}
+          </button>
+        </form>
+
+        {/* ログイン画面への切り替え */}
+        <div className="mt-4 text-center text-sm text-gray-600">
+          既にアカウントをお持ちの方は{' '}
+          <button
+            type="button"
+            onClick={onSwitchToLogin}
+            className="text-blue-600 hover:underline"
+            disabled={isLoading}
+          >
+            ログインはこちら
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Signup;


### PR DESCRIPTION
## 概要
  Issue #11: Web版レコめしアプリにユーザー新規登録機能を実装した。

  ## 実装内容

  ### 新機能
  - **新規登録画面コンポーネント** (`frontend/src/pages/Auth/Signup.tsx`)
    - フォームバリデーション（名前、メール、パスワード、パスワード確認）
    - リアルタイムバリデーション
    - エラーハンドリング
  - **認証API関数** (`frontend/src/api/auth.ts`)
    - signup, login, logout関数
    - 401エラー時の自動トークンクリア
  - **環境変数による動作分岐**
    - `CONFIRMABLE_ENABLED=false`: 確認メール無し、自動ログイン
    - `CONFIRMABLE_ENABLED=true`: 確認メール送信、手動ログイン

  ### 修正・改善
  - **セキュリティ修正**
    - JWT発行の適切な制御（確認メール有効時は未発行）
    - Deviseの自動サインイン抑制
    - dispatch_requestsから/auth/signup除外
  - **UX改善**
    - 全エラーメッセージの日本語化
    - ヘッダーログインボタンの不正動作修正
    - 画面切り替えUIの実装
  - **型安全性向上**
    - AuthResponse型の修正
    - signup関数戻り値型の修正

  ## 編集ファイル

  ### 新規作成
  - `frontend/.env.local`
  - `frontend/src/api/auth.ts`
  - `frontend/src/pages/Auth/Signup.tsx`

  ### 修正
  - `.env` - 環境変数追加
  - `backend/app/models/user.rb` - 動的Devise設定
  - `backend/app/controllers/api/v1/users/registrations_controller.rb` - create方法オーバーライド
  - `backend/app/controllers/api/v1/users/sessions_controller.rb` - 確認チェック分岐
  - `backend/config/initializers/devise.rb` - dispatch_requests修正
  - `backend/config/initializers/cors.rb` - Authorizationヘッダー公開
  - `frontend/src/App.tsx` - 画面切り替え、認証状態管理
  - `frontend/src/pages/Auth/Login.tsx` - Props追加、UI改善
  - `frontend/src/api/client.ts` - 401エラーインターセプター
