### PR TITLE
fix: issue-45 LINE Bot V2       API移行による署名検証修正

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -42,8 +42,8 @@ gem "redis", ">= 4.0.1"
 # Background job processing
 gem "sidekiq"
 
-# LINE Bot API (V1)
-gem "line-bot-api", "~> 1.28", require: "line/bot"
+# LINE Bot API (V2)
+gem "line-bot-api", "~> 2.1", require: "line/bot"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -137,7 +137,7 @@ GEM
     jwt (2.10.2)
       base64
     language_server-protocol (3.17.0.5)
-    line-bot-api (1.30.0)
+    line-bot-api (2.1.1)
       base64 (~> 0.2)
       multipart-post (~> 2.4)
     lint_roller (1.1.0)
@@ -335,7 +335,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   jsonapi-serializer
-  line-bot-api (~> 1.28)
+  line-bot-api (~> 2.1)
   pg (~> 1.1)
   pry-rails
   puma (>= 5.0)


### PR DESCRIPTION
 ## 概要
  LINE Bot Webhook署名検証エラー(issue #45)を解決するため、LINE Bot API
  V2への移行を実施した。

  ### 問題
  - Webhook署名検証が失敗し401 Unauthorizedエラーが発生
  - 旧APIのDeprecation警告が表示: `Line::Bot::Client#validate_signature is
  deprecated`
  - `request.body.read`の多重読み取りによる署名検証の問題

  ### 実装内容
  - **LINE Bot API V2移行**: gemを1.28 → 2.1.1にアップグレード
  - **署名検証の最新化**: `Line::Bot::V2::WebhookParser`を使用した安全な署名検証
  - **リクエスト処理改善**: `request.raw_post`による確実なボディ取得
  - **コード整理**: 不要な手動署名検証ロジックとbefore_actionを削除

  ### 編集ファイル
  - `backend/Gemfile` - LINE Bot API gemバージョン更新
  - `backend/Gemfile.lock` - 依存関係更新
  - `backend/app/services/line_bot_service.rb` - V2パーサー実装
  - `backend/app/controllers/api/v1/line_controller.rb` - Webhook処理最新化