### PR TITLE
feature/issue 14 line authentication

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -59,6 +59,8 @@ group :development, :test do
   gem "rspec-rails", "~> 6.0"
   gem "factory_bot_rails"
   gem "faker"
+  gem "shoulda-matchers", "~> 5.0"
+  gem "timecop"
 end
 
 group :development do

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -293,6 +293,8 @@ GEM
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
+    shoulda-matchers (5.3.0)
+      activesupport (>= 5.2.0)
     sidekiq (8.0.6)
       connection_pool (>= 2.5.0)
       json (>= 2.9.0)
@@ -301,6 +303,7 @@ GEM
       redis-client (>= 0.23.2)
     stringio (3.1.7)
     thor (1.4.0)
+    timecop (0.9.10)
     timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -344,7 +347,9 @@ DEPENDENCIES
   redis (>= 4.0.1)
   rspec-rails (~> 6.0)
   rubocop-rails-omakase
+  shoulda-matchers (~> 5.0)
   sidekiq
+  timecop
   tzinfo-data
 
 BUNDLED WITH

--- a/backend/app/controllers/api/v1/auth/line_auth_controller.rb
+++ b/backend/app/controllers/api/v1/auth/line_auth_controller.rb
@@ -81,7 +81,7 @@ class Api::V1::Auth::LineAuthController < ApplicationController
           code: 'invalid_request',
           message: 'idTokenとnonceが必要です'
         }
-      }, status: :bad_request
+      }, status: :bad_request and return
     end
   end
 

--- a/backend/app/controllers/api/v1/auth/line_auth_controller.rb
+++ b/backend/app/controllers/api/v1/auth/line_auth_controller.rb
@@ -1,0 +1,145 @@
+class Api::V1::Auth::LineAuthController < ApplicationController
+  before_action :authenticate_user!, only: [:line_link, :line_profile]
+  before_action :validate_line_auth_params, only: [:line_login, :line_link]
+
+  def line_login
+    result = LineAuthService.authenticate_with_id_token(
+      id_token: params[:idToken],
+      nonce: params[:nonce]
+    )
+
+    user = result[:user]
+    line_account = result[:line_account]
+
+    # Generate JWT token using existing devise-jwt mechanism
+    token = generate_jwt_token(user)
+
+    render json: {
+      token: token,
+      user: user_response(user),
+      lineAccount: line_account_response(line_account)
+    }, status: :ok
+  rescue LineAuthService::AuthenticationError => e
+    render_auth_error(e.message)
+  end
+
+  def line_link
+    result = LineAuthService.link_existing_user(
+      user: current_user,
+      id_token: params[:idToken],
+      nonce: params[:nonce]
+    )
+
+    line_account = result[:line_account]
+
+    render json: {
+      message: 'LINE account linked successfully',
+      lineAccount: line_account_response(line_account)
+    }, status: :ok
+  rescue LineAuthService::AuthenticationError => e
+    if e.message.include?('already linked to another user')
+      render json: {
+        error: {
+          code: 'already_linked',
+          message: 'このLINEアカウントは既に他のユーザーに連携されています'
+        }
+      }, status: :conflict
+    else
+      render_auth_error(e.message)
+    end
+  end
+
+  def line_profile
+    line_account = current_user.line_account
+
+    unless line_account
+      return render json: {
+        error: {
+          code: 'line_account_not_found',
+          message: 'LINEアカウントが連携されていません'
+        }
+      }, status: :not_found
+    end
+
+    render json: {
+      lineAccount: line_account_response(line_account),
+      user: user_response(current_user)
+    }, status: :ok
+  end
+
+  def generate_nonce
+    nonce = NonceStore.generate_and_store(session.id)
+    render json: { nonce: nonce }, status: :ok
+  end
+
+  private
+
+  def validate_line_auth_params
+    unless params[:idToken].present? && params[:nonce].present?
+      render json: {
+        error: {
+          code: 'invalid_request',
+          message: 'idTokenとnonceが必要です'
+        }
+      }, status: :bad_request
+    end
+  end
+
+  def generate_jwt_token(user)
+    # Use existing devise-jwt mechanism
+    # This assumes Warden::JWTAuth::UserEncoder is available
+    Warden::JWTAuth::UserEncoder.new.call(user, :user, nil).first
+  rescue => e
+    Rails.logger.error "JWT generation failed: #{e.message}"
+    raise LineAuthService::AuthenticationError, 'Failed to generate authentication token'
+  end
+
+  def user_response(user)
+    {
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      provider: user.provider,
+      confirmed: user_confirmed?(user)
+    }
+  end
+
+  def line_account_response(line_account)
+    {
+      id: line_account.id,
+      lineUserId: line_account.line_user_id,
+      displayName: line_account.line_display_name,
+      pictureUrl: line_account.line_picture_url,
+      linkedAt: line_account.linked_at&.iso8601,
+      linked: line_account.linked?
+    }
+  end
+
+  def user_confirmed?(user)
+    if ENV['CONFIRMABLE_ENABLED'] == 'true'
+      user.confirmed_at.present?
+    else
+      true
+    end
+  end
+
+  def render_auth_error(message)
+    error_code = case message
+                 when /expired/i
+                   'expired_token'
+                 when /nonce/i
+                   'nonce_mismatch'
+                 when /audience/i, /aud/i
+                   'aud_mismatch'
+                 else
+                   'invalid_token'
+                 end
+
+    render json: {
+      error: {
+        code: error_code,
+        message: message
+      }
+    }, status: :unauthorized
+  end
+end

--- a/backend/app/lib/jwt_verifier.rb
+++ b/backend/app/lib/jwt_verifier.rb
@@ -1,0 +1,115 @@
+require 'jwt'
+require 'net/http'
+require 'json'
+
+class JwtVerifier
+  class VerificationError < StandardError; end
+  class InvalidTokenError < VerificationError; end
+  class ExpiredTokenError < VerificationError; end
+  class AudienceMismatchError < VerificationError; end
+  class NonceMismatchError < VerificationError; end
+
+  JWKS_URI = 'https://api.line.me/oauth2/v2.1/certs'.freeze
+  JWKS_CACHE_KEY = 'line_jwks'.freeze
+  JWKS_CACHE_TTL = 24.hours.freeze
+  ISSUER = 'https://access.line.me'.freeze
+  ALGORITHM = 'RS256'.freeze
+  CLOCK_SKEW = 5.minutes.freeze
+
+  def self.verify_id_token(id_token:, aud:, nonce: nil)
+    new.verify_id_token(id_token: id_token, aud: aud, nonce: nonce)
+  end
+
+  def verify_id_token(id_token:, aud:, nonce: nil)
+    header = decode_header(id_token)
+    kid = header['kid']
+    
+    raise InvalidTokenError, 'Missing kid in token header' unless kid
+
+    public_key = get_public_key(kid)
+    payload = decode_and_verify_token(id_token, public_key, aud, nonce)
+    
+    {
+      sub: payload['sub'],
+      name: payload['name'],
+      picture: payload['picture'],
+      aud: payload['aud'],
+      iss: payload['iss'],
+      exp: payload['exp'],
+      iat: payload['iat']
+    }
+  rescue JWT::ExpiredSignature
+    raise ExpiredTokenError, 'Token has expired'
+  rescue JWT::InvalidAudError
+    raise AudienceMismatchError, 'Invalid audience'
+  rescue JWT::InvalidIssuerError
+    raise InvalidTokenError, 'Invalid issuer'
+  rescue JWT::DecodeError => e
+    raise InvalidTokenError, "Token decode error: #{e.message}"
+  end
+
+  private
+
+  def decode_header(token)
+    JWT.decode(token, nil, false).last
+  rescue JWT::DecodeError => e
+    raise InvalidTokenError, "Failed to decode token header: #{e.message}"
+  end
+
+  def get_public_key(kid)
+    jwks = fetch_jwks
+    key_data = jwks['keys'].find { |key| key['kid'] == kid }
+    
+    raise InvalidTokenError, "Public key not found for kid: #{kid}" unless key_data
+
+    # Convert JWK to PEM format
+    jwk = JWT::JWK.import(key_data)
+    jwk.public_key
+  rescue => e
+    raise InvalidTokenError, "Failed to get public key: #{e.message}"
+  end
+
+  def fetch_jwks
+    # Try to get from cache first
+    cached_jwks = Rails.cache.read(JWKS_CACHE_KEY)
+    return JSON.parse(cached_jwks) if cached_jwks
+
+    # Fetch from LINE API
+    uri = URI(JWKS_URI)
+    response = Net::HTTP.get_response(uri)
+    
+    raise InvalidTokenError, "Failed to fetch JWKS: #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+
+    jwks_data = response.body
+    
+    # Cache the result
+    Rails.cache.write(JWKS_CACHE_KEY, jwks_data, expires_in: JWKS_CACHE_TTL)
+    
+    JSON.parse(jwks_data)
+  rescue => e
+    raise InvalidTokenError, "Failed to fetch JWKS: #{e.message}"
+  end
+
+  def decode_and_verify_token(token, public_key, aud, nonce)
+    options = {
+      algorithm: ALGORITHM,
+      iss: ISSUER,
+      verify_iss: true,
+      aud: aud,
+      verify_aud: true,
+      verify_exp: true,
+      verify_iat: true,
+      exp_leeway: CLOCK_SKEW.to_i,
+      iat_leeway: CLOCK_SKEW.to_i
+    }
+
+    payload, _ = JWT.decode(token, public_key, true, options)
+    
+    # Verify nonce if provided
+    if nonce && payload['nonce'] != nonce
+      raise NonceMismatchError, 'Nonce mismatch'
+    end
+
+    payload
+  end
+end

--- a/backend/app/models/line_account.rb
+++ b/backend/app/models/line_account.rb
@@ -1,0 +1,21 @@
+class LineAccount < ApplicationRecord
+  belongs_to :user, optional: true
+
+  validates :line_user_id, presence: true, uniqueness: true
+  validates :line_display_name, presence: true
+
+  scope :linked, -> { where.not(user_id: nil) }
+  scope :unlinked, -> { where(user_id: nil) }
+
+  def linked?
+    user_id.present? && linked_at.present?
+  end
+
+  def link_to_user!(user)
+    update!(user: user, linked_at: Time.current)
+  end
+
+  def unlink!
+    update!(user: nil, linked_at: nil)
+  end
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -12,8 +12,13 @@ class User < ApplicationRecord
   
   devise(*devise_modules, jwt_revocation_strategy: JwtDenylist)
 
-  # Validations (emailはvalidatableモジュールに委譲)
+  # Associations
+  has_one :line_account, dependent: :destroy
+
+  # Validations
   validates :name, presence: true, length: { maximum: 50 }
+  validates :email, presence: true, if: -> { provider == 'email' }
+  validates :provider, inclusion: { in: %w[email line] }
 
   # JWT payloadの追加クレームを定義（subはdevise-jwtが自動付与）
   def jwt_payload

--- a/backend/app/services/line_auth_service.rb
+++ b/backend/app/services/line_auth_service.rb
@@ -1,0 +1,133 @@
+class LineAuthService
+  class AuthenticationError < StandardError; end
+
+  def self.authenticate_with_id_token(id_token:, nonce:)
+    new.authenticate_with_id_token(id_token: id_token, nonce: nonce)
+  end
+
+  def self.link_existing_user(user:, id_token:, nonce:)
+    new.link_existing_user(user: user, id_token: id_token, nonce: nonce)
+  end
+
+  def authenticate_with_id_token(id_token:, nonce:)
+    # Verify nonce
+    NonceStore.verify_and_consume(nonce)
+    
+    # Verify ID token
+    line_user_info = JwtVerifier.verify_id_token(
+      id_token: id_token,
+      aud: ENV['LINE_CHANNEL_ID'],
+      nonce: nonce
+    )
+
+    # Find or create LineAccount
+    line_account = find_or_create_line_account(line_user_info)
+    
+    # Find or create User
+    user = find_or_create_user_for_line_account(line_account, line_user_info)
+    
+    { user: user, line_account: line_account }
+  rescue JwtVerifier::VerificationError, NonceStore::NonceError => e
+    raise AuthenticationError, e.message
+  end
+
+  def link_existing_user(user:, id_token:, nonce:)
+    # Verify nonce
+    NonceStore.verify_and_consume(nonce)
+    
+    # Verify ID token
+    line_user_info = JwtVerifier.verify_id_token(
+      id_token: id_token,
+      aud: ENV['LINE_CHANNEL_ID'],
+      nonce: nonce
+    )
+
+    line_user_id = line_user_info[:sub]
+    
+    # Check if LINE account is already linked to another user
+    existing_line_account = LineAccount.find_by(line_user_id: line_user_id)
+    
+    if existing_line_account&.user_id.present? && existing_line_account.user_id != user.id
+      raise AuthenticationError, 'LINE account is already linked to another user'
+    end
+
+    # Create or update LineAccount and link to user
+    line_account = if existing_line_account
+                     existing_line_account.tap do |account|
+                       account.update!(
+                         user: user,
+                         line_display_name: line_user_info[:name],
+                         line_picture_url: line_user_info[:picture],
+                         linked_at: Time.current
+                       )
+                     end
+                   else
+                     LineAccount.create!(
+                       line_user_id: line_user_id,
+                       user: user,
+                       line_display_name: line_user_info[:name],
+                       line_picture_url: line_user_info[:picture],
+                       linked_at: Time.current
+                     )
+                   end
+
+    { user: user, line_account: line_account }
+  rescue JwtVerifier::VerificationError, NonceStore::NonceError => e
+    raise AuthenticationError, e.message
+  end
+
+  private
+
+  def find_or_create_line_account(line_user_info)
+    line_user_id = line_user_info[:sub]
+    
+    line_account = LineAccount.find_by(line_user_id: line_user_id)
+    
+    if line_account
+      # Update profile information
+      line_account.update!(
+        line_display_name: line_user_info[:name],
+        line_picture_url: line_user_info[:picture]
+      )
+      line_account
+    else
+      # Create new LineAccount without user association
+      LineAccount.create!(
+        line_user_id: line_user_id,
+        line_display_name: line_user_info[:name],
+        line_picture_url: line_user_info[:picture]
+      )
+    end
+  end
+
+  def find_or_create_user_for_line_account(line_account, line_user_info)
+    if line_account.user_id.present?
+      # User already exists and is linked
+      line_account.user
+    else
+      # Create new user for LINE authentication
+      user = User.new(
+        name: line_user_info[:name],
+        email: generate_dummy_email(line_user_info[:sub]),
+        password: SecureRandom.alphanumeric(16),
+        provider: 'line'
+      )
+      
+      # Skip email confirmation for LINE users
+      if user.respond_to?(:skip_confirmation!)
+        user.skip_confirmation!
+      end
+      
+      user.save!
+      
+      # Link the LineAccount to the new User
+      line_account.link_to_user!(user)
+      
+      user
+    end
+  end
+
+  def generate_dummy_email(line_user_id)
+    "line_#{line_user_id}@line.local"
+  end
+end

--- a/backend/app/services/line_auth_service.rb
+++ b/backend/app/services/line_auth_service.rb
@@ -128,6 +128,6 @@ class LineAuthService
   end
 
   def generate_dummy_email(line_user_id)
-    "line_#{line_user_id}@line.local"
+    "line_#{line_user_id.downcase}@line.local"
   end
 end

--- a/backend/app/services/nonce_store.rb
+++ b/backend/app/services/nonce_store.rb
@@ -1,0 +1,61 @@
+class NonceStore
+  class NonceError < StandardError; end
+  class NonceNotFoundError < NonceError; end
+  class NonceAlreadyUsedError < NonceError; end
+
+  NONCE_TTL = 10.minutes.freeze
+  NONCE_PREFIX = 'line_nonce:'.freeze
+
+  def self.generate_and_store(session_id = nil)
+    new.generate_and_store(session_id)
+  end
+
+  def self.verify_and_consume(nonce, session_id = nil)
+    new.verify_and_consume(nonce, session_id)
+  end
+
+  def self.cleanup_expired
+    new.cleanup_expired
+  end
+
+  def generate_and_store(session_id = nil)
+    nonce = SecureRandom.uuid
+    key = cache_key(nonce, session_id)
+    
+    Rails.cache.write(key, Time.current.to_i, expires_in: NONCE_TTL)
+    
+    nonce
+  end
+
+  def verify_and_consume(nonce, session_id = nil)
+    key = cache_key(nonce, session_id)
+    
+    # Check if nonce exists
+    stored_time = Rails.cache.read(key)
+    
+    raise NonceNotFoundError, 'Nonce not found or expired' unless stored_time
+    
+    # Delete the nonce immediately to prevent replay
+    Rails.cache.delete(key)
+    
+    # Verify the nonce is not too old (additional check)
+    if Time.current.to_i - stored_time > NONCE_TTL.to_i
+      raise NonceNotFoundError, 'Nonce has expired'
+    end
+
+    true
+  end
+
+  def cleanup_expired
+    # Redis automatically handles TTL expiration, so no manual cleanup needed
+    # This method is provided for compatibility and potential future use
+    true
+  end
+
+  private
+
+  def cache_key(nonce, session_id = nil)
+    base_key = "#{NONCE_PREFIX}#{nonce}"
+    session_id ? "#{base_key}:#{session_id}" : base_key
+  end
+end

--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -12,10 +12,13 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
       # Development environment - Allow local hosts
       origins "localhost:3001",     # Frontend (Web)
               "localhost:3002",     # LIFF
+              "https://localhost:3002", # LIFF (HTTPS)
               "127.0.0.1:3001",    # Alternative localhost
               "127.0.0.1:3002",    # Alternative localhost
+              "https://127.0.0.1:3002", # Alternative localhost (HTTPS)
               "0.0.0.0:3001",      # Docker network
-              "0.0.0.0:3002"       # Docker network
+              "0.0.0.0:3002",      # Docker network
+              "https://0.0.0.0:3002" # Docker network (HTTPS)
     else
       # Production environment - Allow specific domains
       allowed_origins = []

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -24,6 +24,14 @@ Rails.application.routes.draw do
         post 'auth/refresh', to: 'users/refresh#create'
       end
 
+      # LINE Authentication
+      namespace :auth do
+        post 'line_login', to: 'line_auth#line_login'
+        post 'line_link', to: 'line_auth#line_link'
+        get 'line_profile', to: 'line_auth#line_profile'
+        post 'generate_nonce', to: 'line_auth#generate_nonce'
+      end
+
       # LINE Bot Webhook
       post 'line/webhook', to: 'line#webhook'
     end

--- a/backend/db/migrate/20250820030014_create_line_accounts.rb
+++ b/backend/db/migrate/20250820030014_create_line_accounts.rb
@@ -1,0 +1,14 @@
+class CreateLineAccounts < ActiveRecord::Migration[7.2]
+  def change
+    create_table :line_accounts do |t|
+      t.string :line_user_id, null: false
+      t.references :user, null: true, foreign_key: { on_delete: :nullify }
+      t.string :line_display_name
+      t.string :line_picture_url
+      t.datetime :linked_at
+      t.timestamps
+    end
+    
+    add_index :line_accounts, :line_user_id, unique: true
+  end
+end

--- a/backend/db/migrate/20250820031102_add_provider_to_users.rb
+++ b/backend/db/migrate/20250820031102_add_provider_to_users.rb
@@ -1,0 +1,5 @@
+class AddProviderToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :provider, :string, default: 'email'
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_11_072337) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_20_031102) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,18 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_11_072337) do
     t.datetime "updated_at", null: false
     t.index ["exp"], name: "index_jwt_denylists_on_exp"
     t.index ["jti"], name: "index_jwt_denylists_on_jti", unique: true
+  end
+
+  create_table "line_accounts", force: :cascade do |t|
+    t.string "line_user_id", null: false
+    t.bigint "user_id"
+    t.string "line_display_name"
+    t.string "line_picture_url"
+    t.datetime "linked_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["line_user_id"], name: "index_line_accounts_on_line_user_id", unique: true
+    t.index ["user_id"], name: "index_line_accounts_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -36,8 +48,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_11_072337) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "provider", default: "email"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "line_accounts", "users", on_delete: :nullify
 end

--- a/backend/spec/factories/line_accounts.rb
+++ b/backend/spec/factories/line_accounts.rb
@@ -1,0 +1,17 @@
+FactoryBot.define do
+  factory :line_account do
+    sequence(:line_user_id) { |n| "U#{SecureRandom.hex(16)}#{n}" }
+    line_display_name { Faker::Name.name }
+    line_picture_url { Faker::Internet.url(host: 'cdn.line.me', path: '/profile.jpg') }
+
+    trait :linked do
+      association :user
+      linked_at { Time.current }
+    end
+
+    trait :unlinked do
+      user { nil }
+      linked_at { nil }
+    end
+  end
+end

--- a/backend/spec/lib/jwt_verifier_spec.rb
+++ b/backend/spec/lib/jwt_verifier_spec.rb
@@ -180,7 +180,19 @@ RSpec.describe JwtVerifier do
   end
 
   describe 'JWKS caching' do
+    around do |example|
+      original_cache = Rails.cache
+      Rails.cache = ActiveSupport::Cache::MemoryStore.new
+      Rails.cache.clear
+      example.run
+    ensure
+      Rails.cache = original_cache
+    end
+
     it 'caches JWKS response' do
+      # Clear cache first
+      Rails.cache.clear
+      
       expect(Net::HTTP).to receive(:get_response).once.and_return(
         double('response', is_a?: true, body: jwks_response.to_json)
       )

--- a/backend/spec/lib/jwt_verifier_spec.rb
+++ b/backend/spec/lib/jwt_verifier_spec.rb
@@ -1,0 +1,204 @@
+require 'rails_helper'
+
+RSpec.describe JwtVerifier do
+  let(:channel_id) { '2007895268' }
+  let(:nonce) { 'test-nonce-123' }
+  
+  # Mock JWK key for testing
+  let(:test_private_key) { OpenSSL::PKey::RSA.new(2048) }
+  let(:test_public_key) { test_private_key.public_key }
+  let(:kid) { 'test-kid-123' }
+  
+  let(:jwks_response) do
+    {
+      'keys' => [
+        {
+          'kty' => 'RSA',
+          'kid' => kid,
+          'use' => 'sig',
+          'alg' => 'RS256',
+          'n' => Base64.urlsafe_encode64(test_public_key.n.to_s(2), padding: false),
+          'e' => Base64.urlsafe_encode64(test_public_key.e.to_s(2), padding: false)
+        }
+      ]
+    }
+  end
+
+  let(:valid_payload) do
+    {
+      'iss' => 'https://access.line.me',
+      'aud' => channel_id,
+      'sub' => 'U1234567890abcdef',
+      'name' => 'Test User',
+      'picture' => 'https://example.com/picture.jpg',
+      'exp' => (Time.current + 1.hour).to_i,
+      'iat' => Time.current.to_i,
+      'nonce' => nonce
+    }
+  end
+
+  let(:valid_token) do
+    JWT.encode(valid_payload, test_private_key, 'RS256', { 'kid' => kid })
+  end
+
+  before do
+    # Mock JWKS API response
+    allow(Net::HTTP).to receive(:get_response).and_return(
+      double('response', is_a?: true, body: jwks_response.to_json)
+    )
+    allow_any_instance_of(Net::HTTPResponse).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
+    
+    # Clear cache before each test
+    Rails.cache.clear
+  end
+
+  describe '.verify_id_token' do
+    context 'with valid token' do
+      it 'returns decoded payload' do
+        result = described_class.verify_id_token(
+          id_token: valid_token,
+          aud: channel_id,
+          nonce: nonce
+        )
+
+        expect(result[:sub]).to eq('U1234567890abcdef')
+        expect(result[:name]).to eq('Test User')
+        expect(result[:picture]).to eq('https://example.com/picture.jpg')
+        expect(result[:aud]).to eq(channel_id)
+        expect(result[:iss]).to eq('https://access.line.me')
+      end
+    end
+
+    context 'with expired token' do
+      let(:expired_payload) do
+        valid_payload.merge(
+          'exp' => (Time.current - 1.hour).to_i,
+          'iat' => (Time.current - 2.hours).to_i
+        )
+      end
+      let(:expired_token) { JWT.encode(expired_payload, test_private_key, 'RS256', { 'kid' => kid }) }
+
+      it 'raises ExpiredTokenError' do
+        expect {
+          described_class.verify_id_token(
+            id_token: expired_token,
+            aud: channel_id,
+            nonce: nonce
+          )
+        }.to raise_error(JwtVerifier::ExpiredTokenError, 'Token has expired')
+      end
+    end
+
+    context 'with invalid audience' do
+      let(:invalid_aud_payload) { valid_payload.merge('aud' => 'wrong-channel-id') }
+      let(:invalid_aud_token) { JWT.encode(invalid_aud_payload, test_private_key, 'RS256', { 'kid' => kid }) }
+
+      it 'raises AudienceMismatchError' do
+        expect {
+          described_class.verify_id_token(
+            id_token: invalid_aud_token,
+            aud: channel_id,
+            nonce: nonce
+          )
+        }.to raise_error(JwtVerifier::AudienceMismatchError, 'Invalid audience')
+      end
+    end
+
+    context 'with nonce mismatch' do
+      it 'raises NonceMismatchError' do
+        expect {
+          described_class.verify_id_token(
+            id_token: valid_token,
+            aud: channel_id,
+            nonce: 'wrong-nonce'
+          )
+        }.to raise_error(JwtVerifier::NonceMismatchError, 'Nonce mismatch')
+      end
+    end
+
+    context 'with invalid issuer' do
+      let(:invalid_iss_payload) { valid_payload.merge('iss' => 'https://invalid.issuer') }
+      let(:invalid_iss_token) { JWT.encode(invalid_iss_payload, test_private_key, 'RS256', { 'kid' => kid }) }
+
+      it 'raises InvalidTokenError' do
+        expect {
+          described_class.verify_id_token(
+            id_token: invalid_iss_token,
+            aud: channel_id,
+            nonce: nonce
+          )
+        }.to raise_error(JwtVerifier::InvalidTokenError, 'Invalid issuer')
+      end
+    end
+
+    context 'with missing kid in header' do
+      let(:token_without_kid) { JWT.encode(valid_payload, test_private_key, 'RS256') }
+
+      it 'raises InvalidTokenError' do
+        expect {
+          described_class.verify_id_token(
+            id_token: token_without_kid,
+            aud: channel_id,
+            nonce: nonce
+          )
+        }.to raise_error(JwtVerifier::InvalidTokenError, 'Missing kid in token header')
+      end
+    end
+
+    context 'with unknown kid' do
+      let(:unknown_kid_token) { JWT.encode(valid_payload, test_private_key, 'RS256', { 'kid' => 'unknown-kid' }) }
+
+      it 'raises InvalidTokenError' do
+        expect {
+          described_class.verify_id_token(
+            id_token: unknown_kid_token,
+            aud: channel_id,
+            nonce: nonce
+          )
+        }.to raise_error(JwtVerifier::InvalidTokenError, /Public key not found for kid/)
+      end
+    end
+
+    context 'when JWKS API fails' do
+      before do
+        allow(Net::HTTP).to receive(:get_response).and_return(
+          double('response', is_a?: false, code: '500')
+        )
+        allow_any_instance_of(Net::HTTPResponse).to receive(:is_a?).with(Net::HTTPSuccess).and_return(false)
+      end
+
+      it 'raises InvalidTokenError' do
+        expect {
+          described_class.verify_id_token(
+            id_token: valid_token,
+            aud: channel_id,
+            nonce: nonce
+          )
+        }.to raise_error(JwtVerifier::InvalidTokenError, /Failed to fetch JWKS/)
+      end
+    end
+  end
+
+  describe 'JWKS caching' do
+    it 'caches JWKS response' do
+      expect(Net::HTTP).to receive(:get_response).once.and_return(
+        double('response', is_a?: true, body: jwks_response.to_json)
+      )
+      allow_any_instance_of(Net::HTTPResponse).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
+
+      # First call should fetch from API
+      described_class.verify_id_token(
+        id_token: valid_token,
+        aud: channel_id,
+        nonce: nonce
+      )
+
+      # Second call should use cache
+      described_class.verify_id_token(
+        id_token: valid_token,
+        aud: channel_id,
+        nonce: nonce
+      )
+    end
+  end
+end

--- a/backend/spec/models/line_account_spec.rb
+++ b/backend/spec/models/line_account_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+RSpec.describe LineAccount, type: :model do
+  describe 'associations' do
+    it { should belong_to(:user).optional }
+  end
+
+  describe 'validations' do
+    it { should validate_presence_of(:line_user_id) }
+    it { should validate_uniqueness_of(:line_user_id) }
+    it { should validate_presence_of(:line_display_name) }
+  end
+
+  describe 'scopes' do
+    let!(:linked_account) { create(:line_account, :linked) }
+    let!(:unlinked_account) { create(:line_account, :unlinked) }
+
+    describe '.linked' do
+      it 'returns accounts with user_id present' do
+        expect(LineAccount.linked).to include(linked_account)
+        expect(LineAccount.linked).not_to include(unlinked_account)
+      end
+    end
+
+    describe '.unlinked' do
+      it 'returns accounts with user_id nil' do
+        expect(LineAccount.unlinked).to include(unlinked_account)
+        expect(LineAccount.unlinked).not_to include(linked_account)
+      end
+    end
+  end
+
+  describe '#linked?' do
+    context 'when user_id and linked_at are present' do
+      let(:line_account) { create(:line_account, :linked) }
+
+      it 'returns true' do
+        expect(line_account.linked?).to be true
+      end
+    end
+
+    context 'when user_id is nil' do
+      let(:line_account) { create(:line_account, user: nil, linked_at: nil) }
+
+      it 'returns false' do
+        expect(line_account.linked?).to be false
+      end
+    end
+
+    context 'when linked_at is nil' do
+      let(:user) { create(:user) }
+      let(:line_account) { create(:line_account, user: user, linked_at: nil) }
+
+      it 'returns false' do
+        expect(line_account.linked?).to be false
+      end
+    end
+  end
+
+  describe '#link_to_user!' do
+    let(:user) { create(:user) }
+    let(:line_account) { create(:line_account, user: nil, linked_at: nil) }
+
+    it 'links the account to the user and sets linked_at' do
+      freeze_time do
+        line_account.link_to_user!(user)
+        
+        expect(line_account.reload.user).to eq(user)
+        expect(line_account.linked_at).to eq(Time.current)
+      end
+    end
+  end
+
+  describe '#unlink!' do
+    let(:line_account) { create(:line_account, :linked) }
+
+    it 'removes user association and linked_at' do
+      line_account.unlink!
+      
+      expect(line_account.reload.user).to be_nil
+      expect(line_account.linked_at).to be_nil
+    end
+  end
+end

--- a/backend/spec/models/line_account_spec.rb
+++ b/backend/spec/models/line_account_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe LineAccount, type: :model do
   end
 
   describe 'validations' do
+    subject { build(:line_account) }
+    
     it { should validate_presence_of(:line_user_id) }
     it { should validate_uniqueness_of(:line_user_id) }
     it { should validate_presence_of(:line_display_name) }
@@ -62,11 +64,12 @@ RSpec.describe LineAccount, type: :model do
     let(:line_account) { create(:line_account, user: nil, linked_at: nil) }
 
     it 'links the account to the user and sets linked_at' do
-      freeze_time do
+      freeze_time = Time.current
+      Timecop.freeze(freeze_time) do
         line_account.link_to_user!(user)
         
         expect(line_account.reload.user).to eq(user)
-        expect(line_account.linked_at).to eq(Time.current)
+        expect(line_account.linked_at).to be_within(1.second).of(freeze_time)
       end
     end
   end

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -68,3 +68,18 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+
+# Shoulda Matchers configuration
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end
+
+# Timecop configuration
+RSpec.configure do |config|
+  config.after(:each) do
+    Timecop.return
+  end
+end

--- a/backend/spec/requests/api/v1/auth/line_auth_spec.rb
+++ b/backend/spec/requests/api/v1/auth/line_auth_spec.rb
@@ -1,0 +1,232 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Auth::LineAuth', type: :request do
+  let(:id_token) { 'mock-id-token' }
+  let(:nonce) { 'test-nonce-123' }
+  let(:line_user_info) do
+    {
+      sub: 'U1234567890abcdef',
+      name: 'Test User',
+      picture: 'https://example.com/picture.jpg'
+    }
+  end
+
+  before do
+    # Mock authentication services
+    allow(NonceStore).to receive(:verify_and_consume).and_return(true)
+    allow(JwtVerifier).to receive(:verify_id_token).and_return(line_user_info)
+    allow(LineAuthService).to receive(:authenticate_with_id_token).and_call_original
+    allow(LineAuthService).to receive(:link_existing_user).and_call_original
+  end
+
+  describe 'POST /api/v1/auth/line_login' do
+    let(:valid_params) { { idToken: id_token, nonce: nonce } }
+
+    context 'with valid parameters' do
+      it 'authenticates user and returns JWT token' do
+        post '/api/v1/auth/line_login', params: valid_params
+
+        expect(response).to have_http_status(:ok)
+        
+        json_response = JSON.parse(response.body)
+        expect(json_response).to have_key('token')
+        expect(json_response).to have_key('user')
+        expect(json_response).to have_key('lineAccount')
+
+        user_data = json_response['user']
+        expect(user_data['name']).to eq('Test User')
+        expect(user_data['provider']).to eq('line')
+
+        line_account_data = json_response['lineAccount']
+        expect(line_account_data['lineUserId']).to eq('U1234567890abcdef')
+        expect(line_account_data['displayName']).to eq('Test User')
+      end
+    end
+
+    context 'with missing idToken' do
+      let(:invalid_params) { { nonce: nonce } }
+
+      it 'returns bad request error' do
+        post '/api/v1/auth/line_login', params: invalid_params
+
+        expect(response).to have_http_status(:bad_request)
+        
+        json_response = JSON.parse(response.body)
+        expect(json_response['error']['code']).to eq('invalid_request')
+        expect(json_response['error']['message']).to include('idTokenとnonceが必要です')
+      end
+    end
+
+    context 'with missing nonce' do
+      let(:invalid_params) { { idToken: id_token } }
+
+      it 'returns bad request error' do
+        post '/api/v1/auth/line_login', params: invalid_params
+
+        expect(response).to have_http_status(:bad_request)
+        
+        json_response = JSON.parse(response.body)
+        expect(json_response['error']['code']).to eq('invalid_request')
+      end
+    end
+
+    context 'when authentication fails' do
+      before do
+        allow(LineAuthService).to receive(:authenticate_with_id_token)
+          .and_raise(LineAuthService::AuthenticationError, 'Invalid token')
+      end
+
+      it 'returns unauthorized error' do
+        post '/api/v1/auth/line_login', params: valid_params
+
+        expect(response).to have_http_status(:unauthorized)
+        
+        json_response = JSON.parse(response.body)
+        expect(json_response['error']['code']).to eq('invalid_token')
+        expect(json_response['error']['message']).to eq('Invalid token')
+      end
+    end
+
+    context 'when nonce verification fails' do
+      before do
+        allow(LineAuthService).to receive(:authenticate_with_id_token)
+          .and_raise(LineAuthService::AuthenticationError, 'Nonce mismatch')
+      end
+
+      it 'returns nonce mismatch error' do
+        post '/api/v1/auth/line_login', params: valid_params
+
+        expect(response).to have_http_status(:unauthorized)
+        
+        json_response = JSON.parse(response.body)
+        expect(json_response['error']['code']).to eq('nonce_mismatch')
+      end
+    end
+  end
+
+  describe 'POST /api/v1/auth/line_link' do
+    let(:user) { create(:user) }
+    let(:valid_params) { { idToken: id_token, nonce: nonce } }
+    let(:auth_headers) { user.create_new_auth_token }
+
+    before do
+      # Mock JWT authentication
+      allow_any_instance_of(Api::V1::Auth::LineAuthController)
+        .to receive(:authenticate_user!).and_return(true)
+      allow_any_instance_of(Api::V1::Auth::LineAuthController)
+        .to receive(:current_user).and_return(user)
+    end
+
+    context 'with valid parameters and authenticated user' do
+      it 'links LINE account to existing user' do
+        post '/api/v1/auth/line_link', params: valid_params
+
+        expect(response).to have_http_status(:ok)
+        
+        json_response = JSON.parse(response.body)
+        expect(json_response['message']).to eq('LINE account linked successfully')
+        expect(json_response).to have_key('lineAccount')
+
+        line_account_data = json_response['lineAccount']
+        expect(line_account_data['lineUserId']).to eq('U1234567890abcdef')
+        expect(line_account_data['linked']).to be true
+      end
+    end
+
+    context 'when LINE account is already linked to another user' do
+      before do
+        allow(LineAuthService).to receive(:link_existing_user)
+          .and_raise(LineAuthService::AuthenticationError, 'LINE account is already linked to another user')
+      end
+
+      it 'returns conflict error' do
+        post '/api/v1/auth/line_link', params: valid_params
+
+        expect(response).to have_http_status(:conflict)
+        
+        json_response = JSON.parse(response.body)
+        expect(json_response['error']['code']).to eq('already_linked')
+        expect(json_response['error']['message']).to include('既に他のユーザーに連携されています')
+      end
+    end
+
+    context 'without authentication' do
+      before do
+        allow_any_instance_of(Api::V1::Auth::LineAuthController)
+          .to receive(:authenticate_user!).and_raise(StandardError, 'Unauthorized')
+      end
+
+      it 'returns unauthorized error' do
+        expect {
+          post '/api/v1/auth/line_link', params: valid_params
+        }.to raise_error(StandardError, 'Unauthorized')
+      end
+    end
+  end
+
+  describe 'GET /api/v1/auth/line_profile' do
+    let(:user) { create(:user) }
+    let!(:line_account) { create(:line_account, :linked, user: user) }
+
+    before do
+      # Mock JWT authentication
+      allow_any_instance_of(Api::V1::Auth::LineAuthController)
+        .to receive(:authenticate_user!).and_return(true)
+      allow_any_instance_of(Api::V1::Auth::LineAuthController)
+        .to receive(:current_user).and_return(user)
+    end
+
+    context 'with linked LINE account' do
+      it 'returns user and LINE account information' do
+        get '/api/v1/auth/line_profile'
+
+        expect(response).to have_http_status(:ok)
+        
+        json_response = JSON.parse(response.body)
+        expect(json_response).to have_key('user')
+        expect(json_response).to have_key('lineAccount')
+
+        user_data = json_response['user']
+        expect(user_data['id']).to eq(user.id)
+
+        line_account_data = json_response['lineAccount']
+        expect(line_account_data['lineUserId']).to eq(line_account.line_user_id)
+        expect(line_account_data['linked']).to be true
+      end
+    end
+
+    context 'without linked LINE account' do
+      let(:user_without_line) { create(:user) }
+
+      before do
+        allow_any_instance_of(Api::V1::Auth::LineAuthController)
+          .to receive(:current_user).and_return(user_without_line)
+      end
+
+      it 'returns not found error' do
+        get '/api/v1/auth/line_profile'
+
+        expect(response).to have_http_status(:not_found)
+        
+        json_response = JSON.parse(response.body)
+        expect(json_response['error']['code']).to eq('line_account_not_found')
+        expect(json_response['error']['message']).to include('LINEアカウントが連携されていません')
+      end
+    end
+  end
+
+  describe 'POST /api/v1/auth/generate_nonce' do
+    before do
+      allow(NonceStore).to receive(:generate_and_store).and_return('generated-nonce-123')
+    end
+
+    it 'generates and returns a nonce' do
+      post '/api/v1/auth/generate_nonce'
+
+      expect(response).to have_http_status(:ok)
+      
+      json_response = JSON.parse(response.body)
+      expect(json_response['nonce']).to eq('generated-nonce-123')
+    end
+  end
+end

--- a/backend/spec/services/line_auth_service_spec.rb
+++ b/backend/spec/services/line_auth_service_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe LineAuthService do
           expect(user).to be_persisted
           expect(user.provider).to eq('line')
           expect(user.name).to eq('Test User')
-          expect(user.email).to eq('line_U1234567890abcdef@line.local')
+          expect(user.email).to eq('line_u1234567890abcdef@line.local')
 
           expect(line_account).to be_persisted
           expect(line_account.line_user_id).to eq('U1234567890abcdef')
@@ -216,7 +216,7 @@ RSpec.describe LineAuthService do
       end
 
       it 'updates LineAccount information' do
-        freeze_time do
+        Timecop.freeze do
           result = described_class.link_existing_user(
             user: user,
             id_token: id_token,
@@ -227,7 +227,7 @@ RSpec.describe LineAuthService do
 
           expect(line_account).to eq(existing_line_account)
           expect(line_account.reload.line_display_name).to eq('Test User')
-          expect(line_account.linked_at).to eq(Time.current)
+          expect(line_account.linked_at).to be_within(1.second).of(Time.current)
         end
       end
     end

--- a/backend/spec/services/line_auth_service_spec.rb
+++ b/backend/spec/services/line_auth_service_spec.rb
@@ -1,0 +1,235 @@
+require 'rails_helper'
+
+RSpec.describe LineAuthService do
+  let(:id_token) { 'mock-id-token' }
+  let(:nonce) { 'test-nonce-123' }
+  let(:line_user_info) do
+    {
+      sub: 'U1234567890abcdef',
+      name: 'Test User',
+      picture: 'https://example.com/picture.jpg',
+      aud: ENV['LINE_CHANNEL_ID'],
+      iss: 'https://access.line.me'
+    }
+  end
+
+  before do
+    # Mock NonceStore
+    allow(NonceStore).to receive(:verify_and_consume).and_return(true)
+    
+    # Mock JwtVerifier
+    allow(JwtVerifier).to receive(:verify_id_token).and_return(line_user_info)
+  end
+
+  describe '.authenticate_with_id_token' do
+    context 'with new LINE user' do
+      it 'creates new LineAccount and User' do
+        expect {
+          result = described_class.authenticate_with_id_token(
+            id_token: id_token,
+            nonce: nonce
+          )
+
+          user = result[:user]
+          line_account = result[:line_account]
+
+          expect(user).to be_persisted
+          expect(user.provider).to eq('line')
+          expect(user.name).to eq('Test User')
+          expect(user.email).to eq('line_U1234567890abcdef@line.local')
+
+          expect(line_account).to be_persisted
+          expect(line_account.line_user_id).to eq('U1234567890abcdef')
+          expect(line_account.line_display_name).to eq('Test User')
+          expect(line_account.line_picture_url).to eq('https://example.com/picture.jpg')
+          expect(line_account.user).to eq(user)
+          expect(line_account.linked_at).to be_present
+        }.to change(User, :count).by(1)
+         .and change(LineAccount, :count).by(1)
+      end
+    end
+
+    context 'with existing unlinked LineAccount' do
+      let!(:existing_line_account) do
+        create(:line_account, 
+               line_user_id: 'U1234567890abcdef',
+               line_display_name: 'Old Name',
+               user: nil,
+               linked_at: nil)
+      end
+
+      it 'updates LineAccount and creates new User' do
+        expect {
+          result = described_class.authenticate_with_id_token(
+            id_token: id_token,
+            nonce: nonce
+          )
+
+          user = result[:user]
+          line_account = result[:line_account]
+
+          expect(line_account).to eq(existing_line_account)
+          expect(line_account.reload.line_display_name).to eq('Test User')
+          expect(line_account.user).to eq(user)
+          expect(line_account.linked_at).to be_present
+
+          expect(user).to be_persisted
+          expect(user.provider).to eq('line')
+        }.to change(User, :count).by(1)
+         .and change(LineAccount, :count).by(0)
+      end
+    end
+
+    context 'with existing linked LineAccount' do
+      let!(:existing_user) { create(:user, provider: 'line') }
+      let!(:existing_line_account) do
+        create(:line_account, 
+               line_user_id: 'U1234567890abcdef',
+               user: existing_user,
+               linked_at: 1.day.ago)
+      end
+
+      it 'returns existing User and updates LineAccount' do
+        expect {
+          result = described_class.authenticate_with_id_token(
+            id_token: id_token,
+            nonce: nonce
+          )
+
+          user = result[:user]
+          line_account = result[:line_account]
+
+          expect(user).to eq(existing_user)
+          expect(line_account).to eq(existing_line_account)
+          expect(line_account.reload.line_display_name).to eq('Test User')
+        }.to change(User, :count).by(0)
+         .and change(LineAccount, :count).by(0)
+      end
+    end
+
+    context 'when nonce verification fails' do
+      before do
+        allow(NonceStore).to receive(:verify_and_consume)
+          .and_raise(NonceStore::NonceNotFoundError, 'Nonce not found')
+      end
+
+      it 'raises AuthenticationError' do
+        expect {
+          described_class.authenticate_with_id_token(
+            id_token: id_token,
+            nonce: nonce
+          )
+        }.to raise_error(LineAuthService::AuthenticationError, 'Nonce not found')
+      end
+    end
+
+    context 'when JWT verification fails' do
+      before do
+        allow(JwtVerifier).to receive(:verify_id_token)
+          .and_raise(JwtVerifier::InvalidTokenError, 'Invalid token')
+      end
+
+      it 'raises AuthenticationError' do
+        expect {
+          described_class.authenticate_with_id_token(
+            id_token: id_token,
+            nonce: nonce
+          )
+        }.to raise_error(LineAuthService::AuthenticationError, 'Invalid token')
+      end
+    end
+  end
+
+  describe '.link_existing_user' do
+    let(:user) { create(:user) }
+
+    context 'with new LineAccount' do
+      it 'creates LineAccount linked to user' do
+        expect {
+          result = described_class.link_existing_user(
+            user: user,
+            id_token: id_token,
+            nonce: nonce
+          )
+
+          line_account = result[:line_account]
+
+          expect(line_account).to be_persisted
+          expect(line_account.user).to eq(user)
+          expect(line_account.line_user_id).to eq('U1234567890abcdef')
+          expect(line_account.linked_at).to be_present
+        }.to change(LineAccount, :count).by(1)
+      end
+    end
+
+    context 'with existing unlinked LineAccount' do
+      let!(:existing_line_account) do
+        create(:line_account, 
+               line_user_id: 'U1234567890abcdef',
+               user: nil,
+               linked_at: nil)
+      end
+
+      it 'links existing LineAccount to user' do
+        expect {
+          result = described_class.link_existing_user(
+            user: user,
+            id_token: id_token,
+            nonce: nonce
+          )
+
+          line_account = result[:line_account]
+
+          expect(line_account).to eq(existing_line_account)
+          expect(line_account.reload.user).to eq(user)
+          expect(line_account.linked_at).to be_present
+        }.to change(LineAccount, :count).by(0)
+      end
+    end
+
+    context 'with LineAccount linked to another user' do
+      let(:other_user) { create(:user) }
+      let!(:existing_line_account) do
+        create(:line_account, 
+               line_user_id: 'U1234567890abcdef',
+               user: other_user,
+               linked_at: 1.day.ago)
+      end
+
+      it 'raises AuthenticationError' do
+        expect {
+          described_class.link_existing_user(
+            user: user,
+            id_token: id_token,
+            nonce: nonce
+          )
+        }.to raise_error(LineAuthService::AuthenticationError, 'LINE account is already linked to another user')
+      end
+    end
+
+    context 'with LineAccount already linked to same user' do
+      let!(:existing_line_account) do
+        create(:line_account, 
+               line_user_id: 'U1234567890abcdef',
+               user: user,
+               linked_at: 1.day.ago)
+      end
+
+      it 'updates LineAccount information' do
+        freeze_time do
+          result = described_class.link_existing_user(
+            user: user,
+            id_token: id_token,
+            nonce: nonce
+          )
+
+          line_account = result[:line_account]
+
+          expect(line_account).to eq(existing_line_account)
+          expect(line_account.reload.line_display_name).to eq('Test User')
+          expect(line_account.linked_at).to eq(Time.current)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
 ## 概要
  Issue #14の実装として、LINE IDトークン（JWT）による認証機能を実装した。

  ## 実装内容

  ### セキュアなLINE認証システム
  - **JWT検証**: RS256アルゴリズム、JWKs取得、署名検証
  - **IDトークン検証**: iss, aud, exp, iat, nonceの厳密な検証
  - **リプレイ攻撃防止**: nonce検証による一回限りの認証
  - **JWKsキャッシュ**: 24時間TTL、Redisベースの効率的キャッシュ

  ### データベース設計
  - **LineAccountテーブル**: LINE連携情報を管理（line_user_id, linked_at等）
  - **Userテーブル拡張**: provider カラム追加（email/line認証対応）
  - **外部キー制約**: データ整合性とカスケード削除設定

  ### 新規APIエンドポイント
  - `POST /api/v1/auth/line_login` - LINE認証ログイン
  - `POST /api/v1/auth/line_link` - 既存ユーザーとLINE連携
  - `GET /api/v1/auth/line_profile` - LINE連携情報取得
  - `POST /api/v1/auth/generate_nonce` - セキュリティnonce生成

  ### セキュリティ強化
  - **競合防止**: 他ユーザーに連携済みのLINEアカウント検出
  - **CORS設定**: LIFF HTTPS対応（開発・本番環境）
  - **エラーハンドリング**: 統一された詳細なエラーレスポンス

  ## 編集ファイル

  ### 新規作成
  - `backend/app/controllers/api/v1/auth/line_auth_controller.rb` - LINE認証コントローラー
  - `backend/app/lib/jwt_verifier.rb` - JWT検証クラス（JWKsキャッシュ含む）
  - `backend/app/models/line_account.rb` - LINE連携モデル
  - `backend/app/services/line_auth_service.rb` - LINE認証サービス
  - `backend/app/services/nonce_store.rb` - nonce管理サービス
  - `backend/db/migrate/20250820030014_create_line_accounts.rb` - LineAccountsテーブル
  - `backend/db/migrate/20250820031102_add_provider_to_users.rb` - Users拡張
  - `backend/spec/factories/line_accounts.rb` - FactoryBot設定
  - `backend/spec/lib/jwt_verifier_spec.rb` - JWT検証テスト
  - `backend/spec/models/line_account_spec.rb` - LineAccountテスト
  - `backend/spec/requests/api/v1/auth/line_auth_spec.rb` - API統合テスト
  - `backend/spec/services/line_auth_service_spec.rb` - サービステスト

  ### 機能拡張
  - `backend/app/models/user.rb` - LINE認証対応、providerバリデーション
  - `backend/config/routes.rb` - LINE認証エンドポイント追加
  - `backend/config/initializers/cors.rb` - LIFF HTTPS対応
  - `backend/Gemfile` - shoulda-matchers, timecop追加
  - `backend/spec/rails_helper.rb` - テストライブラリ設定