### PR TITLE
feature/issue 25 web ingredients

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,8 @@ import Signup from './pages/Auth/Signup'
 import Header from './components/Header'
 import { AuthProvider } from './contexts/AuthContext'
 import { useAuth } from './hooks/useAuth'
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
+import Ingredients from './pages/Ingredients/Ingredients'
 
 type AuthMode = 'login' | 'signup';
 
@@ -31,20 +33,25 @@ function AppContent() {
 
   return (
     <div className="min-h-screen bg-gray-100">
-      <Header onAuthModeChange={handleAuthModeChange} />
-      
-      <main>
-        {isLoggedIn ? (
-          <Dashboard />
-        ) : authMode === 'login' ? (
-          <Login onSwitchToSignup={handleSwitchToSignup} />
-        ) : (
-          <Signup 
-            onSwitchToLogin={handleSwitchToLogin}
-            onSignupSuccess={handleSignupSuccess}
-          />
-        )}
-      </main>
+      <BrowserRouter>
+        <Header onAuthModeChange={handleAuthModeChange} />
+        <main>
+          {isLoggedIn ? (
+            <Routes>
+              <Route path="/" element={<Dashboard />} />
+              <Route path="/ingredients" element={<Ingredients />} />
+              <Route path="*" element={<Navigate to="/" replace />} />
+            </Routes>
+          ) : authMode === 'login' ? (
+            <Login onSwitchToSignup={handleSwitchToSignup} />
+          ) : (
+            <Signup 
+              onSwitchToLogin={handleSwitchToLogin}
+              onSignupSuccess={handleSignupSuccess}
+            />
+          )}
+        </main>
+      </BrowserRouter>
     </div>
   )
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,8 @@ import { AuthProvider } from './contexts/AuthContext'
 import { useAuth } from './hooks/useAuth'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import Ingredients from './pages/Ingredients/Ingredients'
+import RecipeHistory from './pages/RecipeHistory/RecipeHistory'
+import Settings from './pages/Settings/Settings'
 
 type AuthMode = 'login' | 'signup';
 
@@ -40,6 +42,8 @@ function AppContent() {
             <Routes>
               <Route path="/" element={<Dashboard />} />
               <Route path="/ingredients" element={<Ingredients />} />
+              <Route path="/recipe-history" element={<RecipeHistory />} />
+              <Route path="/settings" element={<Settings />} />
               <Route path="*" element={<Navigate to="/" replace />} />
             </Routes>
           ) : authMode === 'login' ? (

--- a/frontend/src/api/ingredients.ts
+++ b/frontend/src/api/ingredients.ts
@@ -1,0 +1,16 @@
+import { apiClient } from './client'
+import type { IngredientListResponse } from '../types/ingredient'
+
+type GetIngredientsParams = {
+  page?: number
+  per_page?: number
+  search?: string
+  category?: string
+}
+
+// 食材マスタ一覧（ページング/検索）
+export async function getIngredients(params: GetIngredientsParams = {}): Promise<IngredientListResponse> {
+  const res = await apiClient.get('/ingredients', { params })
+  return res.data
+}
+

--- a/frontend/src/api/ingredients.ts
+++ b/frontend/src/api/ingredients.ts
@@ -10,7 +10,7 @@ type GetIngredientsParams = {
 
 // 食材マスタ一覧（ページング/検索）
 export async function getIngredients(params: GetIngredientsParams = {}): Promise<IngredientListResponse> {
-  const res = await apiClient.get('/ingredients', { params })
-  return res.data
+  const res = await apiClient.get<IngredientListResponse>('/ingredients', { params });
+  return res.data;
 }
 

--- a/frontend/src/api/userIngredients.ts
+++ b/frontend/src/api/userIngredients.ts
@@ -1,0 +1,41 @@
+import { apiClient } from './client'
+import type {
+  UserIngredientListResponse,
+  UserIngredientSingleResponse,
+  UserIngredientGroupedResponse,
+  UserIngredientCreateData,
+  UserIngredientUpdateData,
+} from '../types/ingredient'
+
+// 一覧取得（group_by対応）
+export async function getUserIngredients(): Promise<UserIngredientListResponse>
+export async function getUserIngredients(groupBy: 'category'): Promise<UserIngredientGroupedResponse>
+export async function getUserIngredients(
+  groupBy?: 'category'
+): Promise<UserIngredientListResponse | UserIngredientGroupedResponse> {
+  const params = groupBy ? { group_by: groupBy } : undefined
+  const res = await apiClient.get('/user_ingredients', { params })
+  return res.data
+}
+
+// 作成（POST）
+export async function createUserIngredient(data: UserIngredientCreateData): Promise<UserIngredientSingleResponse> {
+  const res = await apiClient.post('/user_ingredients', {
+    user_ingredient: data,
+  })
+  return res.data
+}
+
+// 更新（PUT）
+export async function updateUserIngredient(id: number, data: UserIngredientUpdateData): Promise<UserIngredientSingleResponse> {
+  const res = await apiClient.put(`/user_ingredients/${id}`, {
+    user_ingredient: data,
+  })
+  return res.data
+}
+
+// 削除
+export async function deleteUserIngredient(id: number): Promise<void> {
+  await apiClient.delete(`/user_ingredients/${id}`)
+}
+

--- a/frontend/src/api/userIngredients.ts
+++ b/frontend/src/api/userIngredients.ts
@@ -6,36 +6,46 @@ import type {
   UserIngredientCreateData,
   UserIngredientUpdateData,
 } from '../types/ingredient'
+import { CATEGORY_LABELS, STATUS_LABELS } from '../constants/categories'
+
+type Category = keyof typeof CATEGORY_LABELS;
+type IngredientStatus = keyof typeof STATUS_LABELS;
+type SortBy = 'recent' | 'expiry_date' | 'quantity';
+
+type GetUserIngredientsParams = {
+  status?: IngredientStatus;
+  category?: Category;
+  sort_by?: SortBy;
+  group_by?: 'category';
+}
 
 // 一覧取得（group_by対応）
-export async function getUserIngredients(): Promise<UserIngredientListResponse>
-export async function getUserIngredients(groupBy: 'category'): Promise<UserIngredientGroupedResponse>
-export async function getUserIngredients(
-  groupBy?: 'category'
-): Promise<UserIngredientListResponse | UserIngredientGroupedResponse> {
-  const params = groupBy ? { group_by: groupBy } : undefined
-  const res = await apiClient.get('/user_ingredients', { params })
-  return res.data
+export async function getUserIngredients(params: GetUserIngredientsParams = {}): Promise<UserIngredientListResponse | UserIngredientGroupedResponse> {
+  const res = await apiClient.get<UserIngredientListResponse | UserIngredientGroupedResponse>(
+    '/user_ingredients', 
+    { params }
+  );
+  return res.data;
 }
 
 // 作成（POST）
 export async function createUserIngredient(data: UserIngredientCreateData): Promise<UserIngredientSingleResponse> {
-  const res = await apiClient.post('/user_ingredients', {
+  const res = await apiClient.post<UserIngredientSingleResponse>('/user_ingredients', {
     user_ingredient: data,
-  })
-  return res.data
+  });
+  return res.data;
 }
 
 // 更新（PUT）
 export async function updateUserIngredient(id: number, data: UserIngredientUpdateData): Promise<UserIngredientSingleResponse> {
-  const res = await apiClient.put(`/user_ingredients/${id}`, {
+  const res = await apiClient.put<UserIngredientSingleResponse>(`/user_ingredients/${id}`, {
     user_ingredient: data,
-  })
-  return res.data
+  });
+  return res.data;
 }
 
 // 削除
 export async function deleteUserIngredient(id: number): Promise<void> {
-  await apiClient.delete(`/user_ingredients/${id}`)
+  await apiClient.delete(`/user_ingredients/${id}`);
 }
 

--- a/frontend/src/api/userIngredients.ts
+++ b/frontend/src/api/userIngredients.ts
@@ -6,10 +6,10 @@ import type {
   UserIngredientCreateData,
   UserIngredientUpdateData,
 } from '../types/ingredient'
-import { CATEGORY_LABELS, STATUS_LABELS } from '../constants/categories'
+import { CATEGORY_LABELS } from '../constants/categories'
 
 type Category = keyof typeof CATEGORY_LABELS;
-type IngredientStatus = keyof typeof STATUS_LABELS;
+type IngredientStatus = 'available' | 'used' | 'expired';
 type SortBy = 'recent' | 'expiry_date' | 'quantity';
 
 type GetUserIngredientsParams = {

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useAuth } from '../hooks/useAuth';
+import { Link } from 'react-router-dom';
 
 interface HeaderProps {
   onAuthModeChange?: (mode: 'login' | 'signup') => void;
@@ -36,9 +37,15 @@ const Header: React.FC<HeaderProps> = ({ onAuthModeChange }) => {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center py-4">
           <h1 className="text-2xl font-bold text-gray-900">
-            レコめし
+            <Link to="/" className="hover:opacity-80">レコめし</Link>
           </h1>
           <nav className="flex items-center space-x-4">
+            {isLoggedIn && (
+              <>
+                <Link to="/" className="text-gray-700 hover:text-gray-900">ダッシュボード</Link>
+                <Link to="/ingredients" className="text-gray-700 hover:text-gray-900">食材リスト</Link>
+              </>
+            )}
             {isLoggedIn && user && (
               <span className="text-gray-700">
                 {user.name}さん

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -44,6 +44,8 @@ const Header: React.FC<HeaderProps> = ({ onAuthModeChange }) => {
               <>
                 <Link to="/" className="text-gray-700 hover:text-gray-900">ダッシュボード</Link>
                 <Link to="/ingredients" className="text-gray-700 hover:text-gray-900">食材リスト</Link>
+                <Link to="/recipe-history" className="text-gray-700 hover:text-gray-900">レシピ履歴</Link>
+                <Link to="/settings" className="text-gray-700 hover:text-gray-900">設定</Link>
               </>
             )}
             {isLoggedIn && user && (

--- a/frontend/src/components/ingredients/AddIngredientModal.tsx
+++ b/frontend/src/components/ingredients/AddIngredientModal.tsx
@@ -1,0 +1,111 @@
+import React, { useMemo, useState } from 'react'
+import Modal from '../ui/Modal'
+import { useIngredients } from '../../hooks/useIngredients'
+
+type Props = {
+  isOpen: boolean
+  onClose: () => void
+  onSubmit: (data: { ingredient_id: number; quantity: number; expiry_date?: string | null }) => Promise<void>
+}
+
+const AddIngredientModal: React.FC<Props> = ({ isOpen, onClose, onSubmit }) => {
+  const { items, search, setSearch } = useIngredients({ perPage: 20 })
+  const [selectedId, setSelectedId] = useState<number | ''>('')
+  const [quantity, setQuantity] = useState<number | ''>('')
+  const [expiry, setExpiry] = useState<string>('')
+  const [error, setError] = useState<string | null>(null)
+  
+  const canSubmit = useMemo(() => {
+    const q = Number(quantity)
+    return !!selectedId && !Number.isNaN(q) && q > 0
+  }, [selectedId, quantity])
+
+  const handleSubmit = async () => {
+    setError(null)
+    const q = Number(quantity)
+    if (!selectedId) return
+    if (Number.isNaN(q) || q <= 0) {
+      setError('数量は0より大きい数値で入力してください。')
+      return
+    }
+    // available時に過去日を拒否（MVP簡易チェック）
+    if (expiry) {
+      const today = new Date()
+      today.setHours(0,0,0,0)
+      const d = new Date(expiry)
+      if (d < today) {
+        setError('賞味期限に過去の日付は指定できません。')
+        return
+      }
+    }
+    try {
+      await onSubmit({ ingredient_id: Number(selectedId), quantity: q, expiry_date: expiry || null })
+      setSelectedId('')
+      setQuantity('')
+      setExpiry('')
+      onClose()
+    } catch (e: any) {
+      const msg = e?.response?.data?.status?.message || e?.message || '追加に失敗しました。'
+      setError(msg)
+    }
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="食材を追加">
+      <div className="space-y-3">
+        {error && <div className="text-sm text-red-600 bg-red-50 border border-red-200 p-2 rounded">{error}</div>}
+        <div>
+          <label className="block text-sm text-gray-700 mb-1">食材を検索</label>
+          <input
+            type="text"
+            className="w-full px-3 py-2 border rounded"
+            placeholder="例: にんじん"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-gray-700 mb-1">食材</label>
+          <select className="w-full px-3 py-2 border rounded" value={selectedId} onChange={(e) => setSelectedId(e.target.value ? Number(e.target.value) : '')}>
+            <option value="">選択してください</option>
+            {items.map((i) => (
+              <option key={i.id} value={i.id}>{i.emoji} {i.name}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm text-gray-700 mb-1">数量</label>
+          <input
+            type="number"
+            step="any"
+            className="w-full px-3 py-2 border rounded"
+            value={quantity}
+            onChange={(e) => setQuantity(e.target.value === '' ? '' : Number(e.target.value))}
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-gray-700 mb-1">賞味期限（任意）</label>
+          <input
+            type="date"
+            className="w-full px-3 py-2 border rounded"
+            value={expiry}
+            onChange={(e) => setExpiry(e.target.value)}
+          />
+        </div>
+        <div className="flex justify-end gap-2 pt-2">
+          <button className="px-4 py-2 bg-gray-200 text-gray-800 rounded" onClick={onClose}>キャンセル</button>
+          <button
+            className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+            disabled={!canSubmit}
+            onClick={handleSubmit}
+          >
+            追加
+          </button>
+        </div>
+      </div>
+    </Modal>
+  )
+}
+
+export default AddIngredientModal
+

--- a/frontend/src/components/ingredients/AddIngredientModal.tsx
+++ b/frontend/src/components/ingredients/AddIngredientModal.tsx
@@ -44,9 +44,10 @@ const AddIngredientModal: React.FC<Props> = ({ isOpen, onClose, onSubmit }) => {
       setQuantity('')
       setExpiry('')
       onClose()
-    } catch (e: any) {
-      const msg = e?.response?.data?.status?.message || e?.message || '追加に失敗しました。'
-      setError(msg)
+    } catch (e: unknown) {
+      const error = e as { response?: { data?: { status?: { message?: string } } }; message?: string };
+      const msg = error?.response?.data?.status?.message || error?.message || '追加に失敗しました。';
+      setError(msg);
     }
   }
 

--- a/frontend/src/components/ingredients/EditIngredientModal.tsx
+++ b/frontend/src/components/ingredients/EditIngredientModal.tsx
@@ -47,9 +47,10 @@ const EditIngredientModal: React.FC<Props> = ({ isOpen, item, onClose, onSubmit 
     try {
       await onSubmit({ quantity: q, expiry_date: expiry || null, status })
       onClose()
-    } catch (e: any) {
-      const msg = e?.response?.data?.status?.message || e?.message || '更新に失敗しました。'
-      setError(msg)
+    } catch (e: unknown) {
+      const error = e as { response?: { data?: { status?: { message?: string } } }; message?: string };
+      const msg = error?.response?.data?.status?.message || error?.message || '更新に失敗しました。';
+      setError(msg);
     }
   }
 
@@ -83,7 +84,7 @@ const EditIngredientModal: React.FC<Props> = ({ isOpen, item, onClose, onSubmit 
           <select
             className="w-full px-3 py-2 border rounded"
             value={status}
-            onChange={(e) => setStatus(e.target.value as any)}
+            onChange={(e) => setStatus(e.target.value as 'available' | 'used' | 'expired')}
           >
             <option value="available">利用可能</option>
             <option value="used">使用済み</option>

--- a/frontend/src/components/ingredients/EditIngredientModal.tsx
+++ b/frontend/src/components/ingredients/EditIngredientModal.tsx
@@ -1,0 +1,109 @@
+import React, { useMemo, useState } from 'react'
+import Modal from '../ui/Modal'
+import type { UserIngredient } from '../../types/ingredient'
+
+type Props = {
+  isOpen: boolean
+  item: UserIngredient | null
+  onClose: () => void
+  onSubmit: (data: { quantity?: number; expiry_date?: string | null; status?: 'available' | 'used' | 'expired' }) => Promise<void>
+}
+
+const EditIngredientModal: React.FC<Props> = ({ isOpen, item, onClose, onSubmit }) => {
+  const [quantity, setQuantity] = useState<number | ''>('')
+  const [expiry, setExpiry] = useState<string>('')
+  const [status, setStatus] = useState<'available' | 'used' | 'expired'>(item?.status || 'available')
+  const [error, setError] = useState<string | null>(null)
+
+  React.useEffect(() => {
+    if (item) {
+      setQuantity(item.quantity)
+      setExpiry(item.expiry_date || '')
+      setStatus(item.status)
+    }
+  }, [item])
+
+  const canSubmit = useMemo(() => {
+    const q = quantity === '' ? NaN : Number(quantity)
+    return !Number.isNaN(q) && (q as number) > 0
+  }, [quantity])
+
+  const handleSubmit = async () => {
+    setError(null)
+    const q = Number(quantity)
+    if (Number.isNaN(q) || q <= 0) {
+      setError('数量は0より大きい数値で入力してください。')
+      return
+    }
+    if (status === 'available' && expiry) {
+      const today = new Date()
+      today.setHours(0,0,0,0)
+      const d = new Date(expiry)
+      if (d < today) {
+        setError('賞味期限に過去の日付は指定できません。')
+        return
+      }
+    }
+    try {
+      await onSubmit({ quantity: q, expiry_date: expiry || null, status })
+      onClose()
+    } catch (e: any) {
+      const msg = e?.response?.data?.status?.message || e?.message || '更新に失敗しました。'
+      setError(msg)
+    }
+  }
+
+  const name = item?.ingredient?.name || item?.display_name || ''
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={`${name} を編集`}>
+      <div className="space-y-3">
+        {error && <div className="text-sm text-red-600 bg-red-50 border border-red-200 p-2 rounded">{error}</div>}
+        <div>
+          <label className="block text-sm text-gray-700 mb-1">数量</label>
+          <input
+            type="number"
+            step="any"
+            className="w-full px-3 py-2 border rounded"
+            value={quantity}
+            onChange={(e) => setQuantity(e.target.value === '' ? '' : Number(e.target.value))}
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-gray-700 mb-1">賞味期限（任意）</label>
+          <input
+            type="date"
+            className="w-full px-3 py-2 border rounded"
+            value={expiry}
+            onChange={(e) => setExpiry(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-gray-700 mb-1">ステータス</label>
+          <select
+            className="w-full px-3 py-2 border rounded"
+            value={status}
+            onChange={(e) => setStatus(e.target.value as any)}
+          >
+            <option value="available">利用可能</option>
+            <option value="used">使用済み</option>
+            <option value="expired">期限切れ</option>
+          </select>
+        </div>
+        <div className="flex justify-end gap-2 pt-2">
+          <button className="px-4 py-2 bg-gray-200 text-gray-800 rounded" onClick={onClose}>キャンセル</button>
+          <button
+            className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+            disabled={!canSubmit}
+            onClick={handleSubmit}
+          >
+            保存
+          </button>
+        </div>
+      </div>
+    </Modal>
+  )
+}
+
+export default EditIngredientModal
+

--- a/frontend/src/components/ingredients/IngredientCard.tsx
+++ b/frontend/src/components/ingredients/IngredientCard.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import type { UserIngredient } from '../../types/ingredient'
+
+type Props = {
+  item: UserIngredient
+  onEdit?: (item: UserIngredient) => void
+  onDelete?: (item: UserIngredient) => void
+}
+
+const IngredientCard: React.FC<Props> = ({ item, onEdit, onDelete }) => {
+  const isExpired = item.expired
+  const isSoon = item.expiring_soon
+  const bg = isExpired
+    ? 'bg-red-50 border-red-200'
+    : isSoon
+    ? 'bg-yellow-50 border-yellow-200'
+    : 'bg-gray-50 border-gray-200'
+  const name = item.ingredient?.name || item.display_name
+  const emoji = (item.ingredient as any)?.emoji || ''
+
+  return (
+    <div className={`border ${bg} rounded p-4 flex items-center justify-between`}> 
+      <div>
+        <div className="text-gray-800 font-medium">{emoji} {name}</div>
+        <div className="text-sm text-gray-600 mt-1">
+          {item.days_until_expiry != null ? (
+            <span>期限まで {item.days_until_expiry} 日</span>
+          ) : (
+            <span>期限未設定</span>
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <span className="text-gray-800 mr-2">{item.formatted_quantity}</span>
+        {onEdit && (
+          <button
+            className="px-3 py-1 bg-indigo-600 text-white rounded hover:bg-indigo-700"
+            onClick={() => onEdit(item)}
+          >
+            編集
+          </button>
+        )}
+        {onDelete && (
+          <button
+            className="px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700"
+            onClick={() => onDelete(item)}
+          >
+            削除
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default IngredientCard
+

--- a/frontend/src/components/ingredients/IngredientCard.tsx
+++ b/frontend/src/components/ingredients/IngredientCard.tsx
@@ -16,7 +16,7 @@ const IngredientCard: React.FC<Props> = ({ item, onEdit, onDelete }) => {
     ? 'bg-yellow-50 border-yellow-200'
     : 'bg-gray-50 border-gray-200'
   const name = item.ingredient?.name || item.display_name
-  const emoji = (item.ingredient as any)?.emoji || ''
+  const emoji = item.ingredient?.emoji || ''
 
   return (
     <div className={`border ${bg} rounded p-4 flex items-center justify-between`}> 

--- a/frontend/src/components/ingredients/IngredientFilters.tsx
+++ b/frontend/src/components/ingredients/IngredientFilters.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import { CATEGORY_LABELS } from '../../constants/categories'
+
+type Props = {
+  name: string
+  status: '' | 'available' | 'used' | 'expired'
+  category: string
+  sortBy: 'expiry_date' | 'quantity' | 'recent'
+  onChange: (next: { name?: string; status?: Props['status']; category?: string; sortBy?: Props['sortBy'] }) => void
+}
+
+const IngredientFilters: React.FC<Props> = ({ name, status, category, sortBy, onChange }) => {
+  const handle = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target
+    if (name === 'name') onChange({ name: value })
+  }
+
+  return (
+    <div className="flex flex-col md:flex-row gap-4 mb-6">
+      <input
+        name="name"
+        type="text"
+        placeholder="食材名で検索"
+        className="px-3 py-2 border rounded w-full md:w-64"
+        value={name}
+        onChange={handle}
+      />
+      <select
+        className="px-3 py-2 border rounded"
+        value={status}
+        onChange={(e) => onChange({ status: e.target.value as Props['status'] })}
+      >
+        <option value="">すべてのステータス</option>
+        <option value="available">利用可能</option>
+        <option value="used">使用済み</option>
+        <option value="expired">期限切れ</option>
+      </select>
+      <select
+        className="px-3 py-2 border rounded"
+        value={category}
+        onChange={(e) => onChange({ category: e.target.value })}
+      >
+        <option value="">すべてのカテゴリ</option>
+        {Object.entries(CATEGORY_LABELS).map(([key, label]) => (
+          <option key={key} value={key}>{label}</option>
+        ))}
+      </select>
+      <select
+        className="px-3 py-2 border rounded"
+        value={sortBy}
+        onChange={(e) => onChange({ sortBy: e.target.value as Props['sortBy'] })}
+      >
+        <option value="recent">最新</option>
+        <option value="expiry_date">賞味期限が近い順</option>
+        <option value="quantity">数量が多い順</option>
+      </select>
+    </div>
+  )
+}
+
+export default IngredientFilters
+

--- a/frontend/src/components/ingredients/IngredientList.tsx
+++ b/frontend/src/components/ingredients/IngredientList.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import type { UserIngredient } from '../../types/ingredient'
+import IngredientCard from './IngredientCard'
+import { CATEGORY_LABELS } from '../../constants/categories'
+
+type Props = {
+  groupBy: 'none' | 'category'
+  items: UserIngredient[]
+  groups: Record<string, UserIngredient[]>
+  onEdit: (item: UserIngredient) => void
+  onDelete: (item: UserIngredient) => void
+}
+
+const IngredientList: React.FC<Props> = ({ groupBy, items, groups, onEdit, onDelete }) => {
+  if (groupBy === 'category') {
+    const keys = Object.keys(groups)
+    if (keys.length === 0) return <p className="text-gray-600">食材がありません。</p>
+    return (
+      <div className="space-y-8">
+        {keys.sort().map((category) => (
+          <div key={category}>
+            <h2 className="text-xl font-semibold text-gray-700 mb-4">
+              {CATEGORY_LABELS[category] || category || 'その他'}
+            </h2>
+            <div className="grid grid-cols-1 gap-4">
+              {(groups[category] || []).map((item) => (
+                <IngredientCard key={item.id} item={item} onEdit={onEdit} onDelete={onDelete} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  if (items.length === 0) return <p className="text-gray-600">食材がありません。</p>
+  return (
+    <div className="grid grid-cols-1 gap-4">
+      {items.map((item) => (
+        <IngredientCard key={item.id} item={item} onEdit={onEdit} onDelete={onDelete} />
+      ))}
+    </div>
+  )
+}
+
+export default IngredientList
+

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect } from 'react'
+
+type ModalProps = {
+  isOpen: boolean
+  title?: string
+  onClose: () => void
+  children: React.ReactNode
+}
+
+const Modal: React.FC<ModalProps> = ({ isOpen, title, onClose, children }) => {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    if (isOpen) {
+      window.addEventListener('keydown', handler)
+    }
+    return () => window.removeEventListener('keydown', handler)
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <div className="relative bg-white rounded-lg shadow-lg w-full max-w-lg mx-4">
+        <div className="border-b px-4 py-3 flex justify-between items-center">
+          <h3 className="text-lg font-semibold">{title}</h3>
+          <button onClick={onClose} aria-label="close" className="text-gray-500 hover:text-gray-700">×</button>
+        </div>
+        <div className="p-4">
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default Modal
+

--- a/frontend/src/constants/categories.ts
+++ b/frontend/src/constants/categories.ts
@@ -1,0 +1,9 @@
+export const CATEGORY_LABELS: Record<string, string> = {
+  vegetables: '野菜',
+  meat: '肉類',
+  fish: '魚介類',
+  dairy: '乳製品',
+  seasonings: '調味料',
+  others: 'その他',
+};
+

--- a/frontend/src/hooks/useIngredients.ts
+++ b/frontend/src/hooks/useIngredients.ts
@@ -1,0 +1,54 @@
+import { useCallback, useEffect, useState } from 'react'
+import { getIngredients } from '../api/ingredients'
+import type { Ingredient } from '../types/ingredient'
+
+interface UseIngredientsParams {
+  page?: number
+  perPage?: number
+  search?: string
+  category?: string
+}
+
+export function useIngredients(initial: UseIngredientsParams = {}) {
+  const [items, setItems] = useState<Ingredient[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [page, setPage] = useState(initial.page ?? 1)
+  const [perPage, setPerPage] = useState(initial.perPage ?? 20)
+  const [search, setSearch] = useState(initial.search ?? '')
+  const [category, setCategory] = useState(initial.category ?? '')
+
+  const fetch = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await getIngredients({ page, per_page: perPage, search, category })
+      setItems(res.data)
+    } catch (e) {
+      console.error(e)
+      setError('食材の取得に失敗しました。')
+    } finally {
+      setLoading(false)
+    }
+  }, [page, perPage, search, category])
+
+  useEffect(() => {
+    fetch()
+  }, [fetch])
+
+  return {
+    items,
+    loading,
+    error,
+    page,
+    perPage,
+    search,
+    category,
+    setPage,
+    setPerPage,
+    setSearch,
+    setCategory,
+    refetch: fetch,
+  }
+}
+

--- a/frontend/src/hooks/useUserIngredients.ts
+++ b/frontend/src/hooks/useUserIngredients.ts
@@ -6,11 +6,11 @@ import {
   updateUserIngredient,
 } from '../api/userIngredients'
 import type { UserIngredient } from '../types/ingredient'
-import { CATEGORY_LABELS, STATUS_LABELS } from '../constants/categories'
+import { CATEGORY_LABELS } from '../constants/categories'
 
 type GroupBy = 'none' | 'category'
 type Category = keyof typeof CATEGORY_LABELS;
-type IngredientStatus = keyof typeof STATUS_LABELS;
+type IngredientStatus = 'available' | 'used' | 'expired';
 type SortBy = 'recent' | 'expiry_date' | 'quantity';
 
 interface Filters {

--- a/frontend/src/hooks/useUserIngredients.ts
+++ b/frontend/src/hooks/useUserIngredients.ts
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  createUserIngredient,
+  deleteUserIngredient,
+  getUserIngredients,
+  updateUserIngredient,
+} from '../api/userIngredients'
+import type { UserIngredient, UserIngredientGroupedResponse } from '../types/ingredient'
+
+type GroupBy = 'none' | 'category'
+
+interface Filters {
+  name?: string
+  status?: 'available' | 'used' | 'expired' | ''
+  category?: string | ''
+  sort_by?: 'expiry_date' | 'quantity' | 'recent'
+}
+
+export function useUserIngredients(initialGroupBy: GroupBy = 'category') {
+  const [groupBy, setGroupBy] = useState<GroupBy>(initialGroupBy)
+  const [items, setItems] = useState<UserIngredient[]>([])
+  const [groups, setGroups] = useState<Record<string, UserIngredient[]>>({})
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [filters, setFilters] = useState<Filters>({ sort_by: 'recent' })
+
+  const fetch = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      if (groupBy === 'category') {
+        const res = (await getUserIngredients('category')) as UserIngredientGroupedResponse
+        setGroups(res.data)
+        // フラット化
+        const flattened = Object.values(res.data).flat()
+        setItems(flattened)
+      } else {
+        const res = await getUserIngredients()
+        setItems(res.data)
+        setGroups({})
+      }
+    } catch (e) {
+      console.error(e)
+      setError('在庫の取得に失敗しました。')
+    } finally {
+      setLoading(false)
+    }
+  }, [groupBy])
+
+  useEffect(() => {
+    fetch()
+  }, [fetch])
+
+  const filteredItems = useMemo(() => {
+    let list = [...items]
+    // 名前検索（クライアント側）
+    if (filters.name && filters.name.trim() !== '') {
+      const q = filters.name.trim().toLowerCase()
+      list = list.filter((i) =>
+        (i.ingredient?.name ?? i.display_name).toLowerCase().includes(q)
+      )
+    }
+    // カテゴリフィルタ（クライアント側）
+    if (filters.category) {
+      list = list.filter((i) => (i.ingredient?.category ?? 'others') === filters.category)
+    }
+    // ステータスフィルタ
+    if (filters.status) {
+      list = list.filter((i) => i.status === filters.status)
+    }
+    // ソート
+    const sortBy = filters.sort_by ?? 'recent'
+    if (sortBy === 'expiry_date') {
+      list.sort((a, b) => {
+        const da = a.expiry_date ? new Date(a.expiry_date).getTime() : Infinity
+        const db = b.expiry_date ? new Date(b.expiry_date).getTime() : Infinity
+        return da - db
+      })
+    } else if (sortBy === 'quantity') {
+      list.sort((a, b) => (b.quantity ?? 0) - (a.quantity ?? 0))
+    } else {
+      // recent: updated_at desc
+      list.sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime())
+    }
+    return list
+  }, [items, filters])
+
+  const filteredGroups = useMemo(() => {
+    if (groupBy !== 'category') return {}
+    // filtersをgroupsに適用
+    const result: Record<string, UserIngredient[]> = {}
+    Object.keys(groups).forEach((key) => {
+      result[key] = filteredItems.filter((i) => (i.ingredient?.category ?? 'others') === key)
+    })
+    return result
+  }, [groupBy, groups, filteredItems])
+
+  // CRUD
+  const add = useCallback(async (data: { ingredient_id: number; quantity: number; expiry_date?: string | null }) => {
+    const res = await createUserIngredient(data)
+    const item = res.data
+    setItems((prev) => [item, ...prev])
+    if (groupBy === 'category') {
+      const cat = item.ingredient?.category ?? 'others'
+      setGroups((prev) => ({
+        ...prev,
+        [cat]: [item, ...(prev[cat] || [])],
+      }))
+    }
+    return item
+  }, [groupBy])
+
+  const update = useCallback(async (id: number, data: { quantity?: number; expiry_date?: string | null; status?: 'available' | 'used' | 'expired' }) => {
+    const res = await updateUserIngredient(id, data)
+    const updated = res.data
+    setItems((prev) => prev.map((i) => (i.id === updated.id ? updated : i)))
+    if (groupBy === 'category') {
+      const cat = updated.ingredient?.category ?? 'others'
+      setGroups((prev) => {
+        const next = { ...prev }
+        // 全カテゴリから該当アイテムを除去
+        Object.keys(next).forEach((k) => {
+          next[k] = (next[k] || []).filter((i) => i.id !== updated.id)
+        })
+        next[cat] = [updated, ...(next[cat] || [])]
+        return next
+      })
+    }
+    return updated
+  }, [groupBy])
+
+  const remove = useCallback(async (id: number) => {
+    await deleteUserIngredient(id)
+    setItems((prev) => prev.filter((i) => i.id !== id))
+    if (groupBy === 'category') {
+      setGroups((prev) => {
+        const next = { ...prev }
+        Object.keys(next).forEach((k) => {
+          next[k] = (next[k] || []).filter((i) => i.id !== id)
+          if (next[k].length === 0) delete next[k]
+        })
+        return next
+      })
+    }
+  }, [groupBy])
+
+  return {
+    groupBy,
+    setGroupBy,
+    loading,
+    error,
+    filters,
+    setFilters,
+    items: filteredItems,
+    groups: filteredGroups,
+    refetch: fetch,
+    add,
+    update,
+    remove,
+  }
+}
+

--- a/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -1,27 +1,46 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../../hooks/useAuth';
 
 const Dashboard: React.FC = () => {
+  const { user } = useAuth();
+
   return (
     <div className="min-h-screen bg-gray-50">
       <div className="p-6">
         <div className="max-w-7xl mx-auto">
-        <h1 className="text-3xl font-bold text-gray-900 mb-6">
-          ダッシュボード
-        </h1>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          <div className="bg-white p-6 rounded-lg shadow">
-            <h2 className="text-xl font-semibold mb-4">食材サマリー</h2>
-            <p className="text-gray-600">冷蔵庫の在庫状況を確認</p>
+          <div className="mb-6">
+            <h1 className="text-3xl font-bold text-gray-900">ダッシュボード</h1>
+            <p className="text-gray-600 mt-2">ようこそ、{user?.name || 'ユーザー'}さん</p>
           </div>
-          <div className="bg-white p-6 rounded-lg shadow">
-            <h2 className="text-xl font-semibold mb-4">おすすめレシピ</h2>
-            <p className="text-gray-600">今ある食材で作れるレシピ</p>
+          
+          <div className="bg-white rounded-lg shadow p-6 mb-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              <Link 
+                to="/ingredients" 
+                className="block p-4 bg-blue-50 border border-blue-200 rounded-lg hover:bg-blue-100 transition-colors"
+              >
+                <h2 className="text-lg font-semibold text-blue-900 mb-2">食材リスト</h2>
+                <p className="text-blue-700 text-sm">冷蔵庫の在庫を管理</p>
+              </Link>
+              
+              <Link 
+                to="/recipe-history" 
+                className="block p-4 bg-emerald-50 border border-emerald-200 rounded-lg hover:bg-emerald-100 transition-colors"
+              >
+                <h2 className="text-lg font-semibold text-emerald-900 mb-2">レシピ履歴</h2>
+                <p className="text-emerald-700 text-sm">過去のレシピを確認</p>
+              </Link>
+              
+              <Link 
+                to="/settings" 
+                className="block p-4 bg-gray-50 border border-gray-200 rounded-lg hover:bg-gray-100 transition-colors"
+              >
+                <h2 className="text-lg font-semibold text-gray-700 mb-2">設定</h2>
+                <p className="text-gray-600 text-sm">アカウント設定</p>
+              </Link>
+            </div>
           </div>
-          <div className="bg-white p-6 rounded-lg shadow">
-            <h2 className="text-xl font-semibold mb-4">クイックアクション</h2>
-            <p className="text-gray-600">よく使う機能へのショートカット</p>
-          </div>
-        </div>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/Ingredients/Ingredients.tsx
+++ b/frontend/src/pages/Ingredients/Ingredients.tsx
@@ -1,18 +1,144 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react'
+import { useUserIngredients } from '../../hooks/useUserIngredients'
+import IngredientList from '../../components/ingredients/IngredientList'
+import IngredientFilters from '../../components/ingredients/IngredientFilters'
+import AddIngredientModal from '../../components/ingredients/AddIngredientModal'
+import EditIngredientModal from '../../components/ingredients/EditIngredientModal'
+import type { UserIngredient } from '../../types/ingredient'
 
 const Ingredients: React.FC = () => {
+  const {
+    groupBy,
+    setGroupBy,
+    loading,
+    error,
+    filters,
+    setFilters,
+    items,
+    groups,
+    add,
+    update,
+    remove,
+  } = useUserIngredients('category')
+
+  const [isAddOpen, setIsAddOpen] = useState(false)
+  const [editing, setEditing] = useState<UserIngredient | null>(null)
+  const [pageError, setPageError] = useState<string | null>(null)
+
+  const totalCount = useMemo(() => items.length, [items])
+
+  const handleAdd = async (data: { ingredient_id: number; quantity: number; expiry_date?: string | null }) => {
+    setPageError(null)
+    try {
+      await add(data)
+    } catch (e: any) {
+      const msg = e?.response?.data?.status?.message || e?.message || '追加に失敗しました。'
+      setPageError(msg)
+      throw e
+    }
+  }
+
+  const handleEdit = (item: UserIngredient) => setEditing(item)
+  const handleDelete = async (item: UserIngredient) => {
+    if (!confirm('この食材を削除しますか？')) return
+    try {
+      await remove(item.id)
+    } catch (e) {
+      setPageError('削除に失敗しました。')
+    }
+  }
+
+  const handleUpdate = async (data: { quantity?: number; expiry_date?: string | null; status?: 'available' | 'used' | 'expired' }) => {
+    if (!editing) return
+    setPageError(null)
+    try {
+      await update(editing.id, data)
+      setEditing(null)
+    } catch (e: any) {
+      const msg = e?.response?.data?.status?.message || e?.message || '更新に失敗しました。'
+      setPageError(msg)
+      throw e
+    }
+  }
+
   return (
     <div className="min-h-screen bg-gray-50 p-6">
       <div className="max-w-7xl mx-auto">
-        <h1 className="text-3xl font-bold text-gray-900 mb-6">
-          食材リスト
-        </h1>
+        <div className="flex items-center justify-between mb-6">
+          <h1 className="text-3xl font-bold text-gray-900">食材リスト</h1>
+          <div className="flex items-center gap-2">
+            <button
+              className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+              onClick={() => setIsAddOpen(true)}
+            >
+              追加
+            </button>
+            <button
+              className="px-4 py-2 bg-gray-200 text-gray-800 rounded hover:bg-gray-300"
+              onClick={() => setGroupBy(groupBy === 'category' ? 'none' : 'category')}
+            >
+              {groupBy === 'category' ? 'グループ解除' : 'カテゴリでグループ'}
+            </button>
+          </div>
+        </div>
+
         <div className="bg-white rounded-lg shadow p-6">
-          <p className="text-gray-600">在庫一覧、編集、手動追加機能</p>
+          {loading && <p className="text-gray-600">読み込み中...</p>}
+
+          {!loading && (error || pageError) && (
+            <div className="mb-4 p-3 rounded bg-red-50 text-red-700 border border-red-200">
+              {pageError || error}
+            </div>
+          )}
+
+          {!loading && (
+            <IngredientFilters
+              name={filters.name || ''}
+              status={(filters.status as any) || ''}
+              category={(filters.category as any) || ''}
+              sortBy={(filters.sort_by as any) || 'recent'}
+              onChange={(next) =>
+                setFilters({
+                  ...filters,
+                  ...(next.name !== undefined ? { name: next.name } : {}),
+                  ...(next.status !== undefined ? { status: next.status } : {}),
+                  ...(next.category !== undefined ? { category: next.category } : {}),
+                  ...(next.sortBy !== undefined ? { sort_by: next.sortBy } : {}),
+                })
+              }
+            />
+          )}
+
+          {!loading && totalCount === 0 && (
+            <p className="text-gray-600">食材がありません。</p>
+          )}
+
+          {!loading && totalCount > 0 && (
+            <IngredientList
+              groupBy={groupBy}
+              items={items}
+              groups={groups}
+              onEdit={handleEdit}
+              onDelete={handleDelete}
+            />
+          )}
         </div>
       </div>
-    </div>
-  );
-};
 
-export default Ingredients;
+      <AddIngredientModal
+        isOpen={isAddOpen}
+        onClose={() => setIsAddOpen(false)}
+        onSubmit={handleAdd}
+      />
+
+      <EditIngredientModal
+        isOpen={!!editing}
+        item={editing}
+        onClose={() => setEditing(null)}
+        onSubmit={handleUpdate}
+      />
+    </div>
+  )
+}
+
+export default Ingredients

--- a/frontend/src/pages/Ingredients/Ingredients.tsx
+++ b/frontend/src/pages/Ingredients/Ingredients.tsx
@@ -31,10 +31,11 @@ const Ingredients: React.FC = () => {
     setPageError(null)
     try {
       await add(data)
-    } catch (e: any) {
-      const msg = e?.response?.data?.status?.message || e?.message || '追加に失敗しました。'
-      setPageError(msg)
-      throw e
+    } catch (e: unknown) {
+      const error = e as { response?: { data?: { status?: { message?: string } } }; message?: string };
+      const msg = error?.response?.data?.status?.message || error?.message || '追加に失敗しました。';
+      setPageError(msg);
+      throw e;
     }
   }
 
@@ -43,7 +44,7 @@ const Ingredients: React.FC = () => {
     if (!confirm('この食材を削除しますか？')) return
     try {
       await remove(item.id)
-    } catch (e) {
+    } catch {
       setPageError('削除に失敗しました。')
     }
   }
@@ -54,10 +55,11 @@ const Ingredients: React.FC = () => {
     try {
       await update(editing.id, data)
       setEditing(null)
-    } catch (e: any) {
-      const msg = e?.response?.data?.status?.message || e?.message || '更新に失敗しました。'
-      setPageError(msg)
-      throw e
+    } catch (e: unknown) {
+      const error = e as { response?: { data?: { status?: { message?: string } } }; message?: string };
+      const msg = error?.response?.data?.status?.message || error?.message || '更新に失敗しました。';
+      setPageError(msg);
+      throw e;
     }
   }
 
@@ -94,9 +96,9 @@ const Ingredients: React.FC = () => {
           {!loading && (
             <IngredientFilters
               name={filters.name || ''}
-              status={(filters.status as any) || ''}
-              category={(filters.category as any) || ''}
-              sortBy={(filters.sort_by as any) || 'recent'}
+              status={(filters.status as 'available' | 'used' | 'expired' | '') || ''}
+              category={(filters.category as string) || ''}
+              sortBy={(filters.sort_by as 'expiry_date' | 'quantity' | 'recent') || 'recent'}
               onChange={(next) =>
                 setFilters({
                   ...filters,

--- a/frontend/src/types/ingredient.ts
+++ b/frontend/src/types/ingredient.ts
@@ -1,0 +1,68 @@
+// Ingredient型
+export interface Ingredient {
+  id: number;
+  name: string;
+  category: 'vegetables' | 'meat' | 'fish' | 'dairy' | 'seasonings' | 'others' | string;
+  unit: string;
+  emoji: string;
+}
+
+// UserIngredient型（サーバーシリアライザ準拠）
+export interface UserIngredient {
+  id: number;
+  user_id: number;
+  ingredient_id: number;
+  quantity: number;
+  status: 'available' | 'used' | 'expired';
+  expiry_date: string | null; // YYYY-MM-DD
+  ingredient: Ingredient;
+  display_name: string;
+  formatted_quantity: string;
+  days_until_expiry: number | null;
+  expired: boolean;
+  expiring_soon: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+// API共通
+export interface ApiStatus {
+  code: number;
+  message: string;
+}
+
+// 食材マスタAPIレスポンス
+export interface IngredientListResponse {
+  status: ApiStatus;
+  data: Ingredient[];
+}
+
+// ユーザー食材APIレスポンス
+export interface UserIngredientListResponse {
+  status: ApiStatus;
+  data: UserIngredient[];
+}
+
+export interface UserIngredientSingleResponse {
+  status: ApiStatus;
+  data: UserIngredient;
+}
+
+export interface UserIngredientGroupedResponse {
+  status: ApiStatus;
+  data: Record<string, UserIngredient[]>;
+}
+
+// 更新/作成用データ型
+export interface UserIngredientCreateData {
+  ingredient_id: number;
+  quantity: number;
+  expiry_date?: string | null;
+}
+
+export interface UserIngredientUpdateData {
+  quantity?: number;
+  expiry_date?: string | null;
+  status?: 'available' | 'used' | 'expired';
+}
+

--- a/frontend/test/components/ingredients/IngredientCard.test.tsx
+++ b/frontend/test/components/ingredients/IngredientCard.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import IngredientCard from '../../../src/components/ingredients/IngredientCard'
+
+const baseItem = {
+  id: 1,
+  user_id: 1,
+  ingredient_id: 10,
+  quantity: 1,
+  status: 'available' as const,
+  expiry_date: null,
+  created_at: '2025-01-01T00:00:00Z',
+  updated_at: '2025-01-02T00:00:00Z',
+  ingredient: { id: 10, name: '牛乳', category: 'dairy', unit: '本', emoji: '🥛' },
+  display_name: '牛乳',
+  formatted_quantity: '1本',
+  days_until_expiry: null,
+  expired: false,
+  expiring_soon: false,
+}
+
+describe('IngredientCard', () => {
+  it('renders name and quantity', () => {
+    render(<IngredientCard item={baseItem} />)
+    expect(screen.getByText(/牛乳/)).toBeInTheDocument()
+    expect(screen.getByText('1本')).toBeInTheDocument()
+  })
+
+  it('shows red background when expired', () => {
+    const item = { ...baseItem, expired: true }
+    const { container } = render(<IngredientCard item={item} />)
+    // style class check
+    expect(container.firstChild).toHaveClass('bg-red-50')
+  })
+})
+

--- a/frontend/test/hooks/useUserIngredients.test.tsx
+++ b/frontend/test/hooks/useUserIngredients.test.tsx
@@ -1,0 +1,62 @@
+import { render, waitFor } from '@testing-library/react'
+import React from 'react'
+import { useUserIngredients } from '../../src/hooks/useUserIngredients'
+
+vi.mock('../../src/api/userIngredients', () => ({
+  getUserIngredients: vi.fn(() => Promise.resolve({
+    status: { code: 200, message: 'OK' },
+    data: [
+      {
+        id: 1,
+        user_id: 1,
+        ingredient_id: 10,
+        quantity: 1,
+        status: 'available',
+        expiry_date: null,
+        created_at: '2025-01-01T00:00:00Z',
+        updated_at: '2025-01-02T00:00:00Z',
+        ingredient: { id: 10, name: 'たまねぎ', category: 'vegetables', unit: '個', emoji: '🧅' },
+        display_name: 'たまねぎ',
+        formatted_quantity: '1個',
+        days_until_expiry: null,
+        expired: false,
+        expiring_soon: false,
+      },
+      {
+        id: 2,
+        user_id: 1,
+        ingredient_id: 20,
+        quantity: 2,
+        status: 'available',
+        expiry_date: null,
+        created_at: '2025-01-01T00:00:00Z',
+        updated_at: '2025-01-03T00:00:00Z',
+        ingredient: { id: 20, name: 'にんじん', category: 'vegetables', unit: '本', emoji: '🥕' },
+        display_name: 'にんじん',
+        formatted_quantity: '2本',
+        days_until_expiry: null,
+        expired: false,
+        expiring_soon: false,
+      },
+    ],
+  })) }),
+}))
+
+const TestComp: React.FC = () => {
+  const { items, setFilters, filters } = useUserIngredients('none')
+  React.useEffect(() => {
+    setFilters({ ...filters, name: 'にん' })
+  }, [])
+  return <div data-testid="count">{items.length}</div>
+}
+
+describe('useUserIngredients hook', () => {
+  it('filters by name on client side', async () => {
+    const { getByTestId } = render(<TestComp />)
+    await waitFor(() => {
+      // たまねぎは除外、にんじんのみ
+      expect(getByTestId('count').textContent).toBe('1')
+    })
+  })
+})
+

--- a/frontend/test/hooks/useUserIngredients.test.tsx
+++ b/frontend/test/hooks/useUserIngredients.test.tsx
@@ -39,7 +39,7 @@ vi.mock('../../src/api/userIngredients', () => ({
         expiring_soon: false,
       },
     ],
-  })) }),
+  })),
 }))
 
 const TestComp: React.FC = () => {

--- a/frontend/test/pages/Ingredients.test.tsx
+++ b/frontend/test/pages/Ingredients.test.tsx
@@ -4,8 +4,8 @@ import Ingredients from '../../src/pages/Ingredients/Ingredients'
 import { BrowserRouter } from 'react-router-dom'
 
 vi.mock('../../src/api/userIngredients', () => ({
-  getUserIngredients: vi.fn((groupBy?: 'category') => {
-    if (groupBy === 'category') {
+  getUserIngredients: vi.fn((params: any = {}) => {
+    if (params.group_by === 'category') {
       return Promise.resolve({
         status: { code: 200, message: 'OK' },
         data: {
@@ -54,7 +54,8 @@ describe('Ingredients Page', () => {
     // After load
     await waitFor(() => {
       expect(screen.getByText('食材リスト')).toBeInTheDocument()
-      expect(screen.getByText('野菜')).toBeInTheDocument()
+      // Check for category heading (not the select option)
+      expect(screen.getByRole('heading', { name: '野菜' })).toBeInTheDocument()
       expect(screen.getByText(/にんじん/)).toBeInTheDocument()
     })
   })

--- a/frontend/test/pages/Ingredients.test.tsx
+++ b/frontend/test/pages/Ingredients.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import React from 'react'
+import Ingredients from '../../src/pages/Ingredients/Ingredients'
+import { BrowserRouter } from 'react-router-dom'
+
+vi.mock('../../src/api/userIngredients', () => ({
+  getUserIngredients: vi.fn((groupBy?: 'category') => {
+    if (groupBy === 'category') {
+      return Promise.resolve({
+        status: { code: 200, message: 'OK' },
+        data: {
+          vegetables: [
+            {
+              id: 1,
+              user_id: 1,
+              ingredient_id: 10,
+              quantity: 2,
+              status: 'available',
+              expiry_date: '2099-01-01',
+              created_at: '2025-01-01T00:00:00Z',
+              updated_at: '2025-01-02T00:00:00Z',
+              ingredient: { id: 10, name: 'にんじん', category: 'vegetables', unit: '本', emoji: '🥕' },
+              display_name: 'にんじん',
+              formatted_quantity: '2本',
+              days_until_expiry: 10,
+              expired: false,
+              expiring_soon: false,
+            },
+          ],
+        },
+      })
+    }
+    return Promise.resolve({
+      status: { code: 200, message: 'OK' },
+      data: [],
+    })
+  }),
+  createUserIngredient: vi.fn(),
+  updateUserIngredient: vi.fn(),
+  deleteUserIngredient: vi.fn(),
+}))
+
+describe('Ingredients Page', () => {
+  it('renders and shows grouped list after loading', async () => {
+    render(
+      <BrowserRouter>
+        <Ingredients />
+      </BrowserRouter>
+    )
+
+    // Loading state
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument()
+
+    // After load
+    await waitFor(() => {
+      expect(screen.getByText('食材リスト')).toBeInTheDocument()
+      expect(screen.getByText('野菜')).toBeInTheDocument()
+      expect(screen.getByText(/にんじん/)).toBeInTheDocument()
+    })
+  })
+})
+


### PR DESCRIPTION
## 概要

  Issue #25 の食材リスト画面をWeb版に実装した。

  ### 実装内容

  #### 主要機能
  - 食材一覧表示（カテゴリー別グループ表示対応）
  - 食材の追加・編集・削除機能
  - 検索・フィルター機能
    - 食材名検索（クライアント側）
    - カテゴリー・ステータス・ソートフィルター（サーバー側）
  - 賞味期限警告バッジ表示（期限切れ・期限間近）
  - バリデーション機能（数量>0、過去日不可など）

  #### 技術改善
  - 型安全なAPIクライアント（ジェネリクス対応）
  - サーバー側フィルタリングの活用
  - エラーハンドリングの強化
  - レスポンシブデザイン対応

  #### Web版とLIFF版の統一
  - ダッシュボードの機能統一
  - 全ページへのルーティング追加（/ingredients, /recipe-history, /settings）
  - ヘッダーナビゲーションの充実

  ### 編集ファイル

  #### 新規作成
  - `frontend/src/components/ui/Modal.tsx`
  - `frontend/src/components/ingredients/*` (5ファイル)

  #### 主要修正
  - `frontend/src/pages/Ingredients/Ingredients.tsx` - メイン画面実装
  - `frontend/src/pages/Dashboard/Dashboard.tsx` - LIFF同等の機能提供
  - `frontend/src/App.tsx` - ルーティング追加
  - `frontend/src/components/Header.tsx` - ナビゲーション追加
  - `frontend/src/api/userIngredients.ts` - 型安全性向上
  - `frontend/src/hooks/useUserIngredients.ts` - サーバー側フィルタ対応

  #### テスト
  - `frontend/test/pages/Ingredients.test.tsx` - APIモック修正