### PR TITLE
feature/issue 31 recipe detail screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,6 @@ CLAUDE.md
 
 .tool-versions
 
-CODEX.md
+AGENTS.md
 
 vendor/

--- a/backend/app/controllers/api/v1/recipe_histories_controller.rb
+++ b/backend/app/controllers/api/v1/recipe_histories_controller.rb
@@ -1,0 +1,59 @@
+class Api::V1::RecipeHistoriesController < ApplicationController
+  before_action :authenticate_user!
+
+  # GET /api/v1/recipe_histories
+  def index
+    recipe_histories = current_user.recipe_histories
+                                  .includes(:recipe)
+                                  .recent
+                                  .limit(100)
+
+    render json: {
+      success: true,
+      data: recipe_histories.map { |history| recipe_history_json(history) }
+    }
+  end
+
+  # POST /api/v1/recipe_histories
+  def create
+    recipe_history = current_user.recipe_histories.build(recipe_history_params)
+
+    if recipe_history.save
+      render json: {
+        success: true,
+        data: recipe_history_json(recipe_history),
+        message: '調理記録を保存しました'
+      }, status: :created
+    else
+      render json: {
+        success: false,
+        errors: recipe_history.errors.full_messages,
+        message: '調理記録の保存に失敗しました'
+      }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def recipe_history_params
+    params.require(:recipe_history).permit(:recipe_id, :memo, :cooked_at)
+  end
+
+  def recipe_history_json(history)
+    {
+      id: history.id,
+      user_id: history.user_id,
+      recipe_id: history.recipe_id,
+      cooked_at: history.cooked_at,
+      memo: history.memo,
+      created_at: history.created_at,
+      updated_at: history.updated_at,
+      recipe: history.recipe ? {
+        id: history.recipe.id,
+        title: history.recipe.title,
+        cooking_time: history.recipe.cooking_time,
+        difficulty: history.recipe.difficulty
+      } : nil
+    }
+  end
+end

--- a/backend/app/controllers/api/v1/recipes_controller.rb
+++ b/backend/app/controllers/api/v1/recipes_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::RecipesController < ApplicationController
 
   # GET /api/v1/recipes
   def index
-    recipes = Recipe.includes(:user).recent.limit(50)
+    recipes = current_user.recipes.includes(:user).recent.limit(50)
     render json: {
       success: true,
       data: recipes.map { |recipe| recipe_list_json(recipe) }
@@ -22,7 +22,7 @@ class Api::V1::RecipesController < ApplicationController
   private
 
   def set_recipe
-    @recipe = Recipe.includes(recipe_ingredients: :ingredient).find(params[:id])
+    @recipe = current_user.recipes.includes(recipe_ingredients: :ingredient).find(params[:id])
   end
 
   def recipe_list_json(recipe)

--- a/backend/app/controllers/api/v1/recipes_controller.rb
+++ b/backend/app/controllers/api/v1/recipes_controller.rb
@@ -1,0 +1,55 @@
+class Api::V1::RecipesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_recipe, only: [:show]
+
+  # GET /api/v1/recipes
+  def index
+    recipes = Recipe.includes(:user).recent.limit(50)
+    render json: {
+      success: true,
+      data: recipes.map { |recipe| recipe_list_json(recipe) }
+    }
+  end
+
+  # GET /api/v1/recipes/:id
+  def show
+    render json: {
+      success: true,
+      data: recipe_detail_json(@recipe)
+    }
+  end
+
+  private
+
+  def set_recipe
+    @recipe = Recipe.includes(recipe_ingredients: :ingredient).find(params[:id])
+  end
+
+  def recipe_list_json(recipe)
+    {
+      id: recipe.id,
+      title: recipe.title,
+      cooking_time: recipe.cooking_time,
+      formatted_cooking_time: recipe.formatted_cooking_time,
+      difficulty: recipe.difficulty,
+      difficulty_display: recipe.difficulty_display,
+      servings: recipe.servings,
+      created_at: recipe.created_at
+    }
+  end
+
+  def recipe_detail_json(recipe)
+    recipe_list_json(recipe).merge(
+      steps: recipe.steps_as_array,
+      ingredients: recipe.recipe_ingredients.map do |ri|
+        {
+          id: ri.id,
+          name: ri.ingredient&.name || ri.ingredient_name,
+          amount: ri.amount,
+          unit: ri.unit,
+          is_optional: ri.is_optional
+        }
+      end
+    )
+  end
+end

--- a/backend/app/models/recipe.rb
+++ b/backend/app/models/recipe.rb
@@ -10,6 +10,7 @@ class Recipe < ApplicationRecord
   belongs_to :user
   has_many :recipe_ingredients, dependent: :destroy
   has_many :ingredients, through: :recipe_ingredients
+  has_many :recipe_histories, dependent: :destroy
 
   # Validations
   validates :title, presence: true, length: { maximum: 100 }

--- a/backend/app/models/recipe_history.rb
+++ b/backend/app/models/recipe_history.rb
@@ -1,0 +1,22 @@
+class RecipeHistory < ApplicationRecord
+  # Associations
+  belongs_to :user
+  belongs_to :recipe
+
+  # Validations
+  validates :cooked_at, presence: true
+
+  # Scopes
+  scope :recent, -> { order(cooked_at: :desc) }
+  scope :by_user, ->(user_id) { where(user_id: user_id) }
+  scope :by_recipe, ->(recipe_id) { where(recipe_id: recipe_id) }
+
+  # Instance methods
+  def cooked_date
+    cooked_at.strftime('%Y年%m月%d日')
+  end
+
+  def cooked_time
+    cooked_at.strftime('%H:%M')
+  end
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -17,6 +17,7 @@ class User < ApplicationRecord
   has_many :fridge_images, dependent: :destroy
   has_many :user_ingredients, dependent: :destroy
   has_many :ingredients, through: :user_ingredients
+  has_many :recipes, dependent: :destroy
   has_many :recipe_histories, dependent: :destroy
 
   # Validations

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -17,6 +17,7 @@ class User < ApplicationRecord
   has_many :fridge_images, dependent: :destroy
   has_many :user_ingredients, dependent: :destroy
   has_many :ingredients, through: :user_ingredients
+  has_many :recipe_histories, dependent: :destroy
 
   # Validations
   validates :name, presence: true, length: { maximum: 50 }

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -44,6 +44,10 @@ Rails.application.routes.draw do
       # Ingredients master and user inventory
       resources :ingredients, only: [:index, :create, :update, :destroy]
       resources :user_ingredients
+
+      # Recipes and recipe histories
+      resources :recipes, only: [:index, :show]
+      resources :recipe_histories, only: [:index, :create]
     end
   end
 

--- a/backend/db/migrate/20250907084909_create_recipe_histories.rb
+++ b/backend/db/migrate/20250907084909_create_recipe_histories.rb
@@ -1,0 +1,12 @@
+class CreateRecipeHistories < ActiveRecord::Migration[7.2]
+  def change
+    create_table :recipe_histories do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :recipe, null: false, foreign_key: true
+      t.datetime :cooked_at, null: false, default: -> { 'CURRENT_TIMESTAMP' }
+      t.text :memo
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_05_062219) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_07_084909) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -64,6 +64,17 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_05_062219) do
     t.datetime "updated_at", null: false
     t.index ["line_user_id"], name: "index_line_accounts_on_line_user_id", unique: true
     t.index ["user_id"], name: "index_line_accounts_on_user_id"
+  end
+
+  create_table "recipe_histories", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "recipe_id", null: false
+    t.datetime "cooked_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.text "memo"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["recipe_id"], name: "index_recipe_histories_on_recipe_id"
+    t.index ["user_id"], name: "index_recipe_histories_on_user_id"
   end
 
   create_table "recipe_ingredients", force: :cascade do |t|
@@ -136,6 +147,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_05_062219) do
   add_foreign_key "fridge_images", "line_accounts"
   add_foreign_key "fridge_images", "users"
   add_foreign_key "line_accounts", "users", on_delete: :nullify
+  add_foreign_key "recipe_histories", "recipes"
+  add_foreign_key "recipe_histories", "users"
   add_foreign_key "recipe_ingredients", "ingredients"
   add_foreign_key "recipe_ingredients", "recipes", on_delete: :cascade
   add_foreign_key "recipes", "users"

--- a/backend/spec/factories/recipe_histories.rb
+++ b/backend/spec/factories/recipe_histories.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :recipe_history do
+    association :user
+    association :recipe
+    cooked_at { Time.current }
+    memo { '美味しかった' }
+  end
+end
+

--- a/backend/spec/requests/api/v1/recipe_histories_spec.rb
+++ b/backend/spec/requests/api/v1/recipe_histories_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::RecipeHistories', type: :request do
+  let(:user) { create(:user, :confirmed) }
+
+  def auth_header_for(user)
+    post "/api/v1/auth/login", params: { user: { email: user.email, password: 'password123' } }, as: :json
+    { 'Authorization' => response.headers['Authorization'] }
+  end
+
+  describe 'GET /api/v1/recipe_histories' do
+    let!(:recipe) { create(:recipe, user: user) }
+
+    before do
+      # 自ユーザー2件 + 他ユーザー1件
+      create(:recipe_history, user: user, recipe: recipe, cooked_at: 1.day.ago, memo: 'one')
+      create(:recipe_history, user: user, recipe: recipe, cooked_at: Time.current, memo: 'two')
+      other_user = create(:user, :confirmed)
+      other_recipe = create(:recipe, user: other_user)
+      create(:recipe_history, user: other_user, recipe: other_recipe, cooked_at: Time.current)
+    end
+
+    it '認証なしは401を返す' do
+      get '/api/v1/recipe_histories', as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it '認証済みで自ユーザーの履歴のみを新しい順で返す' do
+      headers = auth_header_for(user)
+      get '/api/v1/recipe_histories', headers: headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body['success']).to eq(true)
+      data = body['data']
+      expect(data).to be_an(Array)
+      expect(data.size).to eq(2)
+
+      cooked_times = data.map { |h| Time.parse(h['cooked_at']) }
+      expect(cooked_times.first).to be >= cooked_times.last
+      # 最低限の埋め込みレシピ情報
+      expect(data.first['recipe']).to include('id', 'title')
+    end
+  end
+
+  describe 'POST /api/v1/recipe_histories' do
+    let!(:recipe) { create(:recipe, user: user) }
+
+    it '認証なしは401を返す' do
+      post '/api/v1/recipe_histories', params: { recipe_history: { recipe_id: recipe.id } }, as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it '有効なパラメータで作成できる' do
+      headers = auth_header_for(user)
+      params = {
+        recipe_history: {
+          recipe_id: recipe.id,
+          memo: 'また作りたい',
+          cooked_at: Time.current.iso8601
+        }
+      }
+
+      post '/api/v1/recipe_histories', params: params, headers: headers, as: :json
+      expect(response).to have_http_status(:created)
+      body = JSON.parse(response.body)
+      expect(body['success']).to eq(true)
+      expect(body['data']).to include('recipe_id' => recipe.id, 'memo' => 'また作りたい')
+    end
+
+    it '不正なパラメータでは422を返す（recipe_id欠如など）' do
+      headers = auth_header_for(user)
+      post '/api/v1/recipe_histories', params: { recipe_history: { memo: 'x', cooked_at: Time.current.iso8601 } }, headers: headers, as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+end
+

--- a/backend/spec/requests/api/v1/recipes_spec.rb
+++ b/backend/spec/requests/api/v1/recipes_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe 'Api::V1::Recipes', type: :request do
 
   describe 'GET /api/v1/recipes' do
     before do
-      # 複数ユーザーのレシピを作成（コントローラは全体のrecentを返す）
+      # 認証ユーザーのレシピを作成（コントローラはcurrent_userのレシピのみを返す）
       create_list(:recipe, 2, user: user)
       other_user = create(:user, :confirmed)
-      create(:recipe, user: other_user)
+      create(:recipe, user: other_user) # このレシピは返されない
     end
 
     it '認証なしは401を返す' do
@@ -29,7 +29,7 @@ RSpec.describe 'Api::V1::Recipes', type: :request do
       body = JSON.parse(response.body)
       expect(body['success']).to eq(true)
       expect(body['data']).to be_an(Array)
-      expect(body['data'].size).to be >= 3
+      expect(body['data'].size).to eq(2) # current_userのレシピのみ返される
 
       sample = body['data'].first
       expect(sample).to include('id', 'title', 'cooking_time', 'formatted_cooking_time', 'difficulty', 'difficulty_display', 'servings', 'created_at')

--- a/backend/spec/requests/api/v1/recipes_spec.rb
+++ b/backend/spec/requests/api/v1/recipes_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Recipes', type: :request do
+  let(:user) { create(:user, :confirmed) }
+
+  def auth_header_for(user)
+    post "/api/v1/auth/login", params: { user: { email: user.email, password: 'password123' } }, as: :json
+    { 'Authorization' => response.headers['Authorization'] }
+  end
+
+  describe 'GET /api/v1/recipes' do
+    before do
+      # 複数ユーザーのレシピを作成（コントローラは全体のrecentを返す）
+      create_list(:recipe, 2, user: user)
+      other_user = create(:user, :confirmed)
+      create(:recipe, user: other_user)
+    end
+
+    it '認証なしは401を返す' do
+      get '/api/v1/recipes', as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it '認証済みでレシピ一覧を返す（最大50件）' do
+      headers = auth_header_for(user)
+      get '/api/v1/recipes', headers: headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body['success']).to eq(true)
+      expect(body['data']).to be_an(Array)
+      expect(body['data'].size).to be >= 3
+
+      sample = body['data'].first
+      expect(sample).to include('id', 'title', 'cooking_time', 'formatted_cooking_time', 'difficulty', 'difficulty_display', 'servings', 'created_at')
+    end
+  end
+
+  describe 'GET /api/v1/recipes/:id' do
+    let!(:recipe) { create(:recipe, user: user) }
+    let!(:ingredient1) { create(:ingredient, name: 'にんじん', unit: '本') }
+    let!(:ri1) { create(:recipe_ingredient, recipe: recipe, ingredient: ingredient1, amount: 1, unit: '本', is_optional: false) }
+    let!(:ri2) { create(:recipe_ingredient, :without_master, recipe: recipe, ingredient: nil, ingredient_name: '塩', amount: nil, unit: nil, is_optional: true) }
+
+    it '認証なしは401を返す' do
+      get "/api/v1/recipes/#{recipe.id}", as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it '認証済みでレシピ詳細を返す（材料・手順を含む）' do
+      headers = auth_header_for(user)
+      get "/api/v1/recipes/#{recipe.id}", headers: headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body['success']).to eq(true)
+      data = body['data']
+
+      expect(data).to include('id' => recipe.id, 'title' => recipe.title)
+      expect(data['steps']).to be_an(Array)
+      # factoryのstepsは構造化→配列文字列化される想定
+      expect(data['steps']).to all(be_a(String))
+
+      expect(data['ingredients']).to be_an(Array)
+      names = data['ingredients'].map { |i| i['name'] }
+      expect(names).to include('にんじん', '塩')
+    end
+  end
+end
+

--- a/liff/src/App.tsx
+++ b/liff/src/App.tsx
@@ -5,6 +5,8 @@ import Home from './pages/Home/Home'
 import Ingredients from './pages/Ingredients/Ingredients'
 import RecipeHistory from './pages/RecipeHistory/RecipeHistory'
 import Settings from './pages/Settings/Settings'
+import RecipeList from './pages/Recipes/RecipeList'
+import RecipeDetail from './pages/Recipes/RecipeDetail'
 
 function App() {
   return (
@@ -14,6 +16,8 @@ function App() {
           <Route path="/" element={<Home />} />
           <Route element={<PrivateRoute />}>
             <Route path="/ingredients" element={<Ingredients />} />
+            <Route path="/recipes" element={<RecipeList />} />
+            <Route path="/recipes/:id" element={<RecipeDetail />} />
             <Route path="/recipe-history" element={<RecipeHistory />} />
             <Route path="/settings" element={<Settings />} />
           </Route>

--- a/liff/src/api/recipes.ts
+++ b/liff/src/api/recipes.ts
@@ -1,0 +1,50 @@
+import { apiClient } from './client'
+import type { Recipe, RecipeHistory, CreateRecipeHistoryParams } from '../types/recipe'
+
+interface ApiResponse<T> {
+  success: boolean
+  data: T
+  message?: string
+  errors?: string[]
+}
+
+export const recipesApi = {
+  // レシピ一覧取得
+  async listRecipes(): Promise<Recipe[]> {
+    const response = await apiClient.get<ApiResponse<Recipe[]>>('/recipes')
+    if (!response.data.success) {
+      throw new Error('レシピ一覧の取得に失敗しました')
+    }
+    return response.data.data
+  },
+
+  // レシピ詳細取得
+  async getRecipe(id: number): Promise<Recipe> {
+    const response = await apiClient.get<ApiResponse<Recipe>>(`/recipes/${id}`)
+    if (!response.data.success) {
+      throw new Error('レシピ詳細の取得に失敗しました')
+    }
+    return response.data.data
+  },
+
+  // 調理履歴一覧取得
+  async listRecipeHistories(): Promise<RecipeHistory[]> {
+    const response = await apiClient.get<ApiResponse<RecipeHistory[]>>('/recipe_histories')
+    if (!response.data.success) {
+      throw new Error('調理履歴の取得に失敗しました')
+    }
+    return response.data.data
+  },
+
+  // 調理履歴作成
+  async createRecipeHistory(params: CreateRecipeHistoryParams): Promise<RecipeHistory> {
+    const response = await apiClient.post<ApiResponse<RecipeHistory>>(
+      '/recipe_histories',
+      { recipe_history: params }
+    )
+    if (!response.data.success) {
+      throw new Error(response.data.message || '調理記録の保存に失敗しました')
+    }
+    return response.data.data
+  }
+}

--- a/liff/src/pages/RecipeHistory/RecipeHistory.tsx
+++ b/liff/src/pages/RecipeHistory/RecipeHistory.tsx
@@ -1,12 +1,126 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import { recipesApi } from '../../api/recipes'
+import type { RecipeHistory as RecipeHistoryType } from '../../types/recipe'
 
 const RecipeHistory: React.FC = () => {
+  const [histories, setHistories] = useState<RecipeHistoryType[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchHistories = async () => {
+      try {
+        setLoading(true)
+        const data = await recipesApi.listRecipeHistories()
+        setHistories(data)
+        setError(null)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : '調理履歴の取得に失敗しました')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchHistories()
+  }, [])
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString)
+    return date.toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    })
+  }
+
+  if (loading) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-2xl font-bold text-gray-800 mb-6">レシピ履歴</h1>
+        <div className="flex justify-center items-center min-h-64">
+          <div className="text-gray-600">読み込み中...</div>
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-2xl font-bold text-gray-800 mb-6">レシピ履歴</h1>
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+          <p className="text-red-700">{error}</p>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="container mx-auto px-4 py-8">
       <h1 className="text-2xl font-bold text-gray-800 mb-6">レシピ履歴</h1>
-      <div className="bg-white rounded-lg shadow-md p-6">
-        <p className="text-gray-600">レシピ履歴が表示されます</p>
-      </div>
+      
+      {histories.length === 0 ? (
+        <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center">
+          <p className="text-gray-600">調理履歴がありません</p>
+          <p className="text-sm text-gray-500 mt-2">
+            レシピを作って「作った！」ボタンを押すと履歴が記録されます
+          </p>
+          <Link
+            to="/recipes"
+            className="inline-block mt-4 bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-lg transition-colors"
+          >
+            レシピを見る
+          </Link>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {histories.map((history) => (
+            <div
+              key={history.id}
+              className="bg-white rounded-lg shadow-md p-4 hover:shadow-lg transition-shadow"
+            >
+              <div className="flex justify-between items-start mb-2">
+                <div className="flex-1">
+                  <h2 className="text-lg font-semibold text-gray-800">
+                    {history.recipe?.title || 'レシピ名不明'}
+                  </h2>
+                  <p className="text-sm text-gray-500">
+                    調理日時: {formatDate(history.cooked_at)}
+                  </p>
+                </div>
+                <Link
+                  to={`/recipes/${history.recipe_id}`}
+                  className="text-blue-500 hover:text-blue-700 text-sm whitespace-nowrap ml-4"
+                >
+                  レシピを見る →
+                </Link>
+              </div>
+              
+              {history.memo && (
+                <div className="mt-3 p-3 bg-gray-50 rounded-lg">
+                  <p className="text-sm text-gray-700">
+                    <strong>メモ:</strong> {history.memo}
+                  </p>
+                </div>
+              )}
+              
+              {history.recipe && (
+                <div className="mt-3 flex items-center space-x-4 text-xs text-gray-500">
+                  {history.recipe.cooking_time && (
+                    <span>⏱ {history.recipe.cooking_time}分</span>
+                  )}
+                  {history.recipe.difficulty && (
+                    <span>難易度: {history.recipe.difficulty}</span>
+                  )}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/liff/src/pages/Recipes/RecipeDetail.tsx
+++ b/liff/src/pages/Recipes/RecipeDetail.tsx
@@ -1,0 +1,220 @@
+import React, { useState, useEffect } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { recipesApi } from '../../api/recipes'
+import type { Recipe, IngredientCheckState } from '../../types/recipe'
+
+const RecipeDetail: React.FC = () => {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const [recipe, setRecipe] = useState<Recipe | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [checkedIngredients, setCheckedIngredients] = useState<IngredientCheckState>({})
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [memo, setMemo] = useState('')
+
+  useEffect(() => {
+    const fetchRecipe = async () => {
+      if (!id) return
+      
+      try {
+        setLoading(true)
+        const data = await recipesApi.getRecipe(parseInt(id, 10))
+        setRecipe(data)
+        setError(null)
+        
+        // 初期状態では全ての材料のチェックを外す
+        if (data.ingredients) {
+          const initialChecked: IngredientCheckState = {}
+          data.ingredients.forEach(ingredient => {
+            initialChecked[ingredient.id] = false
+          })
+          setCheckedIngredients(initialChecked)
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'レシピの取得に失敗しました')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchRecipe()
+  }, [id])
+
+  const handleIngredientCheck = (ingredientId: number) => {
+    setCheckedIngredients(prev => ({
+      ...prev,
+      [ingredientId]: !prev[ingredientId]
+    }))
+  }
+
+  const handleCookedSubmit = async () => {
+    if (!recipe) return
+    
+    try {
+      setIsSubmitting(true)
+      
+      await recipesApi.createRecipeHistory({
+        recipe_id: recipe.id,
+        memo: memo.trim() || undefined
+      })
+      
+      // 成功した場合、履歴ページに遷移
+      alert('調理記録を保存しました！')
+      navigate('/recipe-history')
+    } catch (err) {
+      alert(err instanceof Error ? err.message : '調理記録の保存に失敗しました')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex justify-center items-center min-h-64">
+          <div className="text-gray-600">読み込み中...</div>
+        </div>
+      </div>
+    )
+  }
+
+  if (error || !recipe) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+          <p className="text-red-700">{error || 'レシピが見つかりません'}</p>
+        </div>
+        <button
+          onClick={() => navigate('/recipes')}
+          className="mt-4 text-blue-500 hover:text-blue-700"
+        >
+          ← レシピ一覧に戻る
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      {/* ヘッダー */}
+      <div className="mb-6">
+        <button
+          onClick={() => navigate('/recipes')}
+          className="text-blue-500 hover:text-blue-700 mb-2"
+        >
+          ← レシピ一覧に戻る
+        </button>
+        <h1 className="text-2xl font-bold text-gray-800">{recipe.title}</h1>
+      </div>
+
+      {/* レシピ基本情報 */}
+      <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+        <div className="grid grid-cols-2 gap-4 mb-4">
+          <div className="text-center">
+            <div className="text-sm text-gray-500">調理時間</div>
+            <div className="text-lg font-semibold text-gray-800">
+              ⏱ {recipe.formatted_cooking_time}
+            </div>
+          </div>
+          <div className="text-center">
+            <div className="text-sm text-gray-500">難易度</div>
+            <div className="text-lg font-semibold text-gray-800">
+              {recipe.difficulty_display}
+            </div>
+          </div>
+        </div>
+        {recipe.servings && (
+          <div className="text-center">
+            <div className="text-sm text-gray-500">人数</div>
+            <div className="text-lg font-semibold text-gray-800">
+              👥 {recipe.servings}人分
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* 材料リスト */}
+      <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+        <h2 className="text-xl font-semibold text-gray-800 mb-4">材料</h2>
+        {recipe.ingredients && recipe.ingredients.length > 0 ? (
+          <div className="space-y-3">
+            {recipe.ingredients.map((ingredient) => (
+              <label
+                key={ingredient.id}
+                className="flex items-center space-x-3 cursor-pointer hover:bg-gray-50 p-2 rounded"
+              >
+                <input
+                  type="checkbox"
+                  checked={checkedIngredients[ingredient.id] || false}
+                  onChange={() => handleIngredientCheck(ingredient.id)}
+                  className="w-5 h-5 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500"
+                />
+                <div className="flex-1">
+                  <span className={`${checkedIngredients[ingredient.id] ? 'line-through text-gray-500' : 'text-gray-800'}`}>
+                    {ingredient.name}
+                  </span>
+                  {(ingredient.amount || ingredient.unit) && (
+                    <span className="text-gray-600 ml-2">
+                      {ingredient.amount && `${ingredient.amount}`}
+                      {ingredient.unit && `${ingredient.unit}`}
+                    </span>
+                  )}
+                  {ingredient.is_optional && (
+                    <span className="text-sm text-gray-500 ml-2">(お好みで)</span>
+                  )}
+                </div>
+              </label>
+            ))}
+          </div>
+        ) : (
+          <p className="text-gray-500">材料情報がありません</p>
+        )}
+      </div>
+
+      {/* 調理手順 */}
+      <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+        <h2 className="text-xl font-semibold text-gray-800 mb-4">調理手順</h2>
+        {recipe.steps && recipe.steps.length > 0 ? (
+          <ol className="space-y-4">
+            {recipe.steps.map((step, index) => (
+              <li key={index} className="flex">
+                <span className="bg-blue-500 text-white text-sm font-bold rounded-full w-8 h-8 flex items-center justify-center mr-3 mt-1 flex-shrink-0">
+                  {index + 1}
+                </span>
+                <p className="text-gray-800 leading-relaxed">{step}</p>
+              </li>
+            ))}
+          </ol>
+        ) : (
+          <p className="text-gray-500">調理手順がありません</p>
+        )}
+      </div>
+
+      {/* メモ入力 */}
+      <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+        <h2 className="text-xl font-semibold text-gray-800 mb-4">メモ（任意）</h2>
+        <textarea
+          value={memo}
+          onChange={(e) => setMemo(e.target.value)}
+          placeholder="作った感想や工夫した点などを記録できます"
+          className="w-full p-3 border border-gray-300 rounded-lg resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          rows={3}
+        />
+      </div>
+
+      {/* 作ったボタン */}
+      <div className="sticky bottom-0 bg-white border-t border-gray-200 p-4 -mx-4">
+        <button
+          onClick={handleCookedSubmit}
+          disabled={isSubmitting}
+          className="w-full bg-green-500 hover:bg-green-600 disabled:bg-gray-300 text-white font-bold py-3 px-6 rounded-lg transition-colors"
+        >
+          {isSubmitting ? '保存中...' : '🍽 作った！'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default RecipeDetail

--- a/liff/src/pages/Recipes/RecipeList.tsx
+++ b/liff/src/pages/Recipes/RecipeList.tsx
@@ -1,0 +1,105 @@
+import React, { useState, useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import { recipesApi } from '../../api/recipes'
+import type { Recipe } from '../../types/recipe'
+
+const RecipeList: React.FC = () => {
+  const [recipes, setRecipes] = useState<Recipe[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchRecipes = async () => {
+      try {
+        setLoading(true)
+        const data = await recipesApi.listRecipes()
+        setRecipes(data)
+        setError(null)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'レシピの取得に失敗しました')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchRecipes()
+  }, [])
+
+  if (loading) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex justify-center items-center min-h-64">
+          <div className="text-gray-600">読み込み中...</div>
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+          <p className="text-red-700">{error}</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold text-gray-800 mb-6">レシピ一覧</h1>
+      
+      {recipes.length === 0 ? (
+        <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center">
+          <p className="text-gray-600">レシピが見つかりません</p>
+          <p className="text-sm text-gray-500 mt-2">
+            LINEで食材の写真を送信してレシピを作成してみてください
+          </p>
+        </div>
+      ) : (
+        <div className="grid gap-4">
+          {recipes.map((recipe) => (
+            <Link
+              key={recipe.id}
+              to={`/recipes/${recipe.id}`}
+              className="block bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow p-4"
+            >
+              <div className="flex justify-between items-start mb-2">
+                <h2 className="text-lg font-semibold text-gray-800 line-clamp-2">
+                  {recipe.title}
+                </h2>
+                <span className="text-sm text-gray-500 whitespace-nowrap ml-2">
+                  {new Date(recipe.created_at).toLocaleDateString('ja-JP', {
+                    month: 'short',
+                    day: 'numeric'
+                  })}
+                </span>
+              </div>
+              
+              <div className="flex items-center justify-between text-sm text-gray-600">
+                <div className="flex items-center space-x-4">
+                  <span className="flex items-center">
+                    ⏱ {recipe.formatted_cooking_time}
+                  </span>
+                  <span className="flex items-center">
+                    {recipe.difficulty_display}
+                  </span>
+                  {recipe.servings && (
+                    <span className="flex items-center">
+                      👥 {recipe.servings}人分
+                    </span>
+                  )}
+                </div>
+                <span className="text-blue-500">
+                  詳細を見る →
+                </span>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default RecipeList

--- a/liff/src/types/recipe.ts
+++ b/liff/src/types/recipe.ts
@@ -1,0 +1,47 @@
+export interface Recipe {
+  id: number
+  title: string
+  cooking_time: number
+  formatted_cooking_time: string
+  difficulty: 'easy' | 'medium' | 'hard' | null
+  difficulty_display: string
+  servings: number | null
+  created_at: string
+  steps?: string[]
+  ingredients?: RecipeIngredient[]
+}
+
+export interface RecipeIngredient {
+  id: number
+  name: string
+  amount: number | null
+  unit: string | null
+  is_optional: boolean
+}
+
+export interface RecipeHistory {
+  id: number
+  user_id: number
+  recipe_id: number
+  cooked_at: string
+  memo: string | null
+  created_at: string
+  updated_at: string
+  recipe?: {
+    id: number
+    title: string
+    cooking_time: number
+    difficulty: string | null
+  }
+}
+
+export interface CreateRecipeHistoryParams {
+  recipe_id: number
+  memo?: string
+  cooked_at?: string
+}
+
+// チェックボックス用のローカル状態
+export interface IngredientCheckState {
+  [ingredientId: number]: boolean
+}

--- a/liff/src/types/recipe.ts
+++ b/liff/src/types/recipe.ts
@@ -42,6 +42,4 @@ export interface CreateRecipeHistoryParams {
 }
 
 // チェックボックス用のローカル状態
-export interface IngredientCheckState {
-  [ingredientId: number]: boolean
-}
+export type IngredientCheckState = Record<number, boolean>

--- a/liff/test/RecipeDetail.test.tsx
+++ b/liff/test/RecipeDetail.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import RecipeDetail from '../src/pages/Recipes/RecipeDetail'
+import * as recipesApiModule from '../src/api/recipes'
+
+vi.mock('../src/api/recipes', () => ({
+  recipesApi: {
+    getRecipe: vi.fn(),
+    createRecipeHistory: vi.fn(),
+  },
+}))
+
+const mockRecipesApi = vi.mocked(recipesApiModule.recipesApi)
+
+const renderWithRoute = (ui: React.ReactNode, initialPath = '/recipes/1') => {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/recipes/:id" element={ui} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe('RecipeDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // alertのモック
+    vi.spyOn(window, 'alert').mockImplementation(() => {})
+  })
+
+  it('ローディング表示', () => {
+    mockRecipesApi.getRecipe.mockImplementation(() => new Promise(() => {}))
+    renderWithRoute(<RecipeDetail />)
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument()
+  })
+
+  it('詳細表示と材料チェックの切り替え', async () => {
+    mockRecipesApi.getRecipe.mockResolvedValue({
+      id: 1,
+      title: '煮物',
+      cooking_time: 20,
+      formatted_cooking_time: '20分',
+      difficulty: 'easy',
+      difficulty_display: '簡単 ⭐',
+      servings: 2,
+      created_at: new Date().toISOString(),
+      steps: ['切る', '煮る'],
+      ingredients: [
+        { id: 11, name: '大根', amount: 200, unit: 'g', is_optional: false },
+        { id: 12, name: 'しょうゆ', amount: null, unit: null, is_optional: true },
+      ],
+    })
+
+    renderWithRoute(<RecipeDetail />)
+
+    await waitFor(() => {
+      expect(screen.getByText('煮物')).toBeInTheDocument()
+      expect(screen.getByText('材料')).toBeInTheDocument()
+      expect(screen.getByText('調理手順')).toBeInTheDocument()
+    })
+
+    const checkbox = screen.getAllByRole('checkbox')[0]
+    // 初期は未チェック
+    expect(checkbox).not.toBeChecked()
+    fireEvent.click(checkbox)
+    expect(checkbox).toBeChecked()
+  })
+
+  it('「作った！」で履歴作成APIが呼ばれる', async () => {
+    mockRecipesApi.getRecipe.mockResolvedValue({
+      id: 1,
+      title: 'テスト',
+      cooking_time: 10,
+      formatted_cooking_time: '10分',
+      difficulty: 'easy',
+      difficulty_display: '簡単 ⭐',
+      servings: 1,
+      created_at: new Date().toISOString(),
+      steps: ['手順'],
+      ingredients: [],
+    })
+    mockRecipesApi.createRecipeHistory.mockResolvedValue({
+      id: 1,
+      user_id: 1,
+      recipe_id: 1,
+      cooked_at: new Date().toISOString(),
+      memo: 'メモ',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    } as any)
+
+    renderWithRoute(<RecipeDetail />)
+
+    await waitFor(() => {
+      expect(screen.getByText('テスト')).toBeInTheDocument()
+    })
+
+    const textarea = screen.getByPlaceholderText('作った感想や工夫した点などを記録できます')
+    fireEvent.change(textarea, { target: { value: 'メモ' } })
+
+    const button = screen.getByRole('button', { name: '🍽 作った！' })
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(mockRecipesApi.createRecipeHistory).toHaveBeenCalledWith({ recipe_id: 1, memo: 'メモ' })
+      expect(window.alert).toHaveBeenCalled()
+    })
+  })
+})
+

--- a/liff/test/RecipeList.test.tsx
+++ b/liff/test/RecipeList.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
+import RecipeList from '../src/pages/Recipes/RecipeList'
+import * as recipesApiModule from '../src/api/recipes'
+
+vi.mock('../src/api/recipes', () => ({
+  recipesApi: {
+    listRecipes: vi.fn(),
+  },
+}))
+
+const mockRecipesApi = vi.mocked(recipesApiModule.recipesApi)
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <BrowserRouter>{children}</BrowserRouter>
+)
+
+describe('RecipeList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('ローディング表示', () => {
+    mockRecipesApi.listRecipes.mockImplementation(() => new Promise(() => {}))
+    render(<RecipeList />, { wrapper: Wrapper })
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument()
+  })
+
+  it('レシピがない場合の空表示', async () => {
+    mockRecipesApi.listRecipes.mockResolvedValue([])
+    render(<RecipeList />, { wrapper: Wrapper })
+    await waitFor(() => {
+      expect(screen.getByText('レシピが見つかりません')).toBeInTheDocument()
+    })
+  })
+
+  it('レシピ一覧表示', async () => {
+    const now = new Date().toISOString()
+    mockRecipesApi.listRecipes.mockResolvedValue([
+      {
+        id: 1,
+        title: 'テストレシピA',
+        cooking_time: 10,
+        formatted_cooking_time: '10分',
+        difficulty: 'easy',
+        difficulty_display: '簡単 ⭐',
+        servings: 1,
+        created_at: now,
+      },
+      {
+        id: 2,
+        title: 'テストレシピB',
+        cooking_time: 30,
+        formatted_cooking_time: '30分',
+        difficulty: 'medium',
+        difficulty_display: '普通 ⭐⭐',
+        servings: 2,
+        created_at: now,
+      },
+    ])
+
+    render(<RecipeList />, { wrapper: Wrapper })
+
+    await waitFor(() => {
+      expect(screen.getByText('テストレシピA')).toBeInTheDocument()
+      expect(screen.getByText('テストレシピB')).toBeInTheDocument()
+      expect(screen.getByText('⏱ 10分')).toBeInTheDocument()
+      expect(screen.getByText('普通 ⭐⭐')).toBeInTheDocument()
+      expect(screen.getByText('👥 2人分')).toBeInTheDocument()
+    })
+  })
+})
+

--- a/liff/test/recipes-api.test.ts
+++ b/liff/test/recipes-api.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { recipesApi } from '../src/api/recipes'
+import { apiClient } from '../src/api/client'
+
+vi.mock('../src/api/client', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}))
+
+const mockApiClient = vi.mocked(apiClient)
+
+describe('recipes API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('listRecipes: 一覧を取得し成功時にデータを返す', async () => {
+    const mockData = [
+      {
+        id: 1,
+        title: 'テストレシピ',
+        cooking_time: 15,
+        formatted_cooking_time: '15分',
+        difficulty: 'easy',
+        difficulty_display: '簡単 ⭐',
+        servings: 1,
+        created_at: new Date().toISOString(),
+      },
+    ]
+    mockApiClient.get.mockResolvedValueOnce({ data: { success: true, data: mockData } })
+
+    const result = await recipesApi.listRecipes()
+    expect(mockApiClient.get).toHaveBeenCalledWith('/recipes')
+    expect(result).toEqual(mockData)
+  })
+
+  it('getRecipe: 詳細を取得し成功時にデータを返す', async () => {
+    const mockRecipe = {
+      id: 1,
+      title: 'テストレシピ',
+      cooking_time: 15,
+      formatted_cooking_time: '15分',
+      difficulty: 'easy' as const,
+      difficulty_display: '簡単 ⭐',
+      servings: 1,
+      created_at: new Date().toISOString(),
+      steps: ['手順1', '手順2'],
+      ingredients: [
+        { id: 10, name: 'にんじん', amount: 1, unit: '本', is_optional: false },
+      ],
+    }
+    mockApiClient.get.mockResolvedValueOnce({ data: { success: true, data: mockRecipe } })
+
+    const result = await recipesApi.getRecipe(1)
+    expect(mockApiClient.get).toHaveBeenCalledWith('/recipes/1')
+    expect(result).toEqual(mockRecipe)
+  })
+
+  it('listRecipeHistories: 履歴一覧を取得', async () => {
+    const mockHistories = [
+      {
+        id: 1,
+        user_id: 1,
+        recipe_id: 1,
+        cooked_at: new Date().toISOString(),
+        memo: 'テスト',
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+    ]
+    mockApiClient.get.mockResolvedValueOnce({ data: { success: true, data: mockHistories } })
+
+    const result = await recipesApi.listRecipeHistories()
+    expect(mockApiClient.get).toHaveBeenCalledWith('/recipe_histories')
+    expect(result).toEqual(mockHistories)
+  })
+
+  it('createRecipeHistory: 履歴を作成', async () => {
+    const mockHistory = {
+      id: 1,
+      user_id: 1,
+      recipe_id: 1,
+      cooked_at: new Date().toISOString(),
+      memo: 'また作りたい',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }
+    mockApiClient.post.mockResolvedValueOnce({ data: { success: true, data: mockHistory } })
+
+    const result = await recipesApi.createRecipeHistory({ recipe_id: 1, memo: 'また作りたい' })
+    expect(mockApiClient.post).toHaveBeenCalledWith('/recipe_histories', { recipe_history: { recipe_id: 1, memo: 'また作りたい' } })
+    expect(result).toEqual(mockHistory)
+  })
+
+  it('APIのsuccess=false時はエラーを投げる', async () => {
+    mockApiClient.get.mockResolvedValueOnce({ data: { success: false, data: [] } } as any)
+    await expect(recipesApi.listRecipes()).rejects.toThrow()
+  })
+})
+


### PR DESCRIPTION
## 概要

  Issue #31「LIFFアプリのレシピ詳細画面実装」を完了した。

 ### 実装内容

  バックエンド機能
  - RecipeHistoryモデルとマイグレーションの追加（調理履歴管理）
  - RecipesControllerの追加（レシピ一覧・詳細API）
  - RecipeHistoriesControllerの追加（調理履歴作成・一覧API）
  - セキュリティ修正：全てのレシピクエリをcurrent_userでスコープ化
  - Userモデルにrecipes associationを追加
  - Recipeモデルにrecipe_histories associationを追加

  フロントエンド機能（LIFF）
  - Recipe、RecipeIngredient、RecipeHistory型定義の追加
  - recipes APIクライアントの実装
  - RecipeListコンポーネント（レシピ一覧）
  - RecipeDetailコンポーネント（レシピ詳細・材料チェック・調理記録）
  - RecipeHistoryコンポーネントの完全実装（調理履歴表示）
  - App.tsxにレシピ関連ルーティングを追加

 ### 編集ファイル

  バックエンド
  - backend/db/migrate/20250907084909_create_recipe_histories.rb（新規）
  - backend/app/models/recipe_history.rb（新規）
  - backend/app/controllers/api/v1/recipes_controller.rb（新規）
  - backend/app/controllers/api/v1/recipe_histories_controller.rb（新規）
  - backend/app/models/user.rb（修正：recipes association追加）
  - backend/app/models/recipe.rb（修正：recipe_histories association追加）
  - backend/config/routes.rb（修正：レシピ関連ルート追加）
  - backend/db/schema.rb（修正：migration反映）

  フロントエンド（LIFF）
  - liff/src/types/recipe.ts（新規）
  - liff/src/api/recipes.ts（新規）
  - liff/src/pages/Recipes/RecipeList.tsx（新規）
  - liff/src/pages/Recipes/RecipeDetail.tsx（新規）
  - liff/src/pages/RecipeHistory/RecipeHistory.tsx（修正：完全実装）
  - liff/src/App.tsx（修正：ルート追加）

  テスト
  - backend/spec/factories/recipe_histories.rb（新規）
  - backend/spec/requests/api/v1/recipes_spec.rb（新規）
  - backend/spec/requests/api/v1/recipe_histories_spec.rb（新規）
  - liff/test/RecipeList.test.tsx（新規）
  - liff/test/RecipeDetail.test.tsx（新規）
  - liff/test/recipes-api.test.ts（新規）
  - liff/test/AuthContext.test.tsx（修正）
  - liff/test/useAuth.test.tsx（修正）