### PR TITLE
feature/issue 38 recipe history rating

### DIFF
--- a/backend/app/controllers/api/v1/recipe_histories_controller.rb
+++ b/backend/app/controllers/api/v1/recipe_histories_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::RecipeHistoriesController < ApplicationController
   before_action :authenticate_user!
+  before_action :find_recipe_history, only: [ :show, :update ]
 
   # GET /api/v1/recipe_histories
   def index
@@ -14,6 +15,14 @@ class Api::V1::RecipeHistoriesController < ApplicationController
     }
   end
 
+  # GET /api/v1/recipe_histories/:id
+  def show
+    render json: {
+      success: true,
+      data: recipe_history_json(@recipe_history)
+    }
+  end
+
   # POST /api/v1/recipe_histories
   def create
     recipe_history = current_user.recipe_histories.build(recipe_history_params)
@@ -22,21 +31,46 @@ class Api::V1::RecipeHistoriesController < ApplicationController
       render json: {
         success: true,
         data: recipe_history_json(recipe_history),
-        message: '調理記録を保存しました'
+        message: "調理記録を保存しました"
       }, status: :created
     else
       render json: {
         success: false,
         errors: recipe_history.errors.full_messages,
-        message: '調理記録の保存に失敗しました'
+        message: "調理記録の保存に失敗しました"
+      }, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH /api/v1/recipe_histories/:id
+  def update
+    if @recipe_history.update(update_params)
+      render json: {
+        success: true,
+        data: recipe_history_json(@recipe_history),
+        message: "評価を更新しました"
+      }
+    else
+      render json: {
+        success: false,
+        errors: @recipe_history.errors.full_messages,
+        message: "評価の更新に失敗しました"
       }, status: :unprocessable_entity
     end
   end
 
   private
 
+  def find_recipe_history
+    @recipe_history = current_user.recipe_histories.find(params[:id])
+  end
+
   def recipe_history_params
-    params.require(:recipe_history).permit(:recipe_id, :memo, :cooked_at)
+    params.require(:recipe_history).permit(:recipe_id, :memo, :cooked_at, :rating)
+  end
+
+  def update_params
+    params.require(:recipe_history).permit(:rating)
   end
 
   def recipe_history_json(history)
@@ -46,6 +80,7 @@ class Api::V1::RecipeHistoriesController < ApplicationController
       recipe_id: history.recipe_id,
       cooked_at: history.cooked_at,
       memo: history.memo,
+      rating: history.rating,
       created_at: history.created_at,
       updated_at: history.updated_at,
       recipe: history.recipe ? {

--- a/backend/app/models/recipe_history.rb
+++ b/backend/app/models/recipe_history.rb
@@ -1,22 +1,32 @@
 class RecipeHistory < ApplicationRecord
+  # Constants
+  RATING_RANGE = (1..5).freeze
+
   # Associations
   belongs_to :user
   belongs_to :recipe
 
   # Validations
   validates :cooked_at, presence: true
+  validates :rating, numericality: {
+    only_integer: true,
+    allow_nil: true,
+    in: RATING_RANGE
+  }
 
   # Scopes
   scope :recent, -> { order(cooked_at: :desc) }
   scope :by_user, ->(user_id) { where(user_id: user_id) }
   scope :by_recipe, ->(recipe_id) { where(recipe_id: recipe_id) }
+  scope :rated, -> { where.not(rating: nil) }
+  scope :unrated, -> { where(rating: nil) }
 
   # Instance methods
   def cooked_date
-    cooked_at.strftime('%Y年%m月%d日')
+    cooked_at.strftime("%Y年%m月%d日")
   end
 
   def cooked_time
-    cooked_at.strftime('%H:%M')
+    cooked_at.strftime("%H:%M")
   end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -47,7 +47,7 @@ Rails.application.routes.draw do
 
       # Recipes and recipe histories
       resources :recipes, only: [:index, :show]
-      resources :recipe_histories, only: [:index, :create]
+      resources :recipe_histories, only: [:index, :show, :create, :update]
     end
   end
 

--- a/backend/db/migrate/20250908064315_add_rating_to_recipe_histories.rb
+++ b/backend/db/migrate/20250908064315_add_rating_to_recipe_histories.rb
@@ -1,0 +1,6 @@
+class AddRatingToRecipeHistories < ActiveRecord::Migration[7.2]
+  def change
+    add_column :recipe_histories, :rating, :integer, null: true
+    add_check_constraint :recipe_histories, 'rating BETWEEN 1 AND 5', name: 'rating_between_1_and_5'
+  end
+end

--- a/backend/db/migrate/20250908064416_add_index_to_recipe_histories_user_id_cooked_at.rb
+++ b/backend/db/migrate/20250908064416_add_index_to_recipe_histories_user_id_cooked_at.rb
@@ -1,0 +1,5 @@
+class AddIndexToRecipeHistoriesUserIdCookedAt < ActiveRecord::Migration[7.2]
+  def change
+    add_index :recipe_histories, [:user_id, :cooked_at], name: 'index_recipe_histories_on_user_id_and_cooked_at'
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_07_084909) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_08_064416) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -73,8 +73,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_07_084909) do
     t.text "memo"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "rating"
     t.index ["recipe_id"], name: "index_recipe_histories_on_recipe_id"
+    t.index ["user_id", "cooked_at"], name: "index_recipe_histories_on_user_id_and_cooked_at"
     t.index ["user_id"], name: "index_recipe_histories_on_user_id"
+    t.check_constraint "rating >= 1 AND rating <= 5", name: "rating_between_1_and_5"
   end
 
   create_table "recipe_ingredients", force: :cascade do |t|

--- a/backend/spec/factories/recipe_histories.rb
+++ b/backend/spec/factories/recipe_histories.rb
@@ -4,6 +4,22 @@ FactoryBot.define do
     association :recipe
     cooked_at { Time.current }
     memo { '美味しかった' }
+    rating { nil }
+
+    trait :rated do
+      rating { 3 }
+    end
+
+    trait :unrated do
+      rating { nil }
+    end
+
+    trait :highly_rated do
+      rating { 5 }
+    end
+
+    trait :poorly_rated do
+      rating { 1 }
+    end
   end
 end
-

--- a/backend/spec/models/recipe_history_spec.rb
+++ b/backend/spec/models/recipe_history_spec.rb
@@ -1,0 +1,116 @@
+require 'rails_helper'
+
+RSpec.describe RecipeHistory, type: :model do
+  let(:user) { create(:user) }
+  let(:recipe) { create(:recipe) }
+
+  describe 'associations' do
+    it { should belong_to(:user) }
+    it { should belong_to(:recipe) }
+  end
+
+  describe 'validations' do
+    subject { build(:recipe_history) }
+
+    it { should validate_presence_of(:cooked_at) }
+
+    describe 'rating validation' do
+      it 'allows nil rating' do
+        recipe_history = build(:recipe_history, rating: nil)
+        expect(recipe_history).to be_valid
+      end
+
+      it 'allows valid ratings (1-5)' do
+        (1..5).each do |rating|
+          recipe_history = build(:recipe_history, rating: rating)
+          expect(recipe_history).to be_valid
+        end
+      end
+
+      it 'rejects ratings below 1' do
+        recipe_history = build(:recipe_history, rating: 0)
+        expect(recipe_history).not_to be_valid
+        expect(recipe_history.errors[:rating]).to be_present
+      end
+
+      it 'rejects ratings above 5' do
+        recipe_history = build(:recipe_history, rating: 6)
+        expect(recipe_history).not_to be_valid
+        expect(recipe_history.errors[:rating]).to be_present
+      end
+
+      it 'rejects non-integer ratings' do
+        recipe_history = build(:recipe_history, rating: 3.5)
+        expect(recipe_history).not_to be_valid
+        expect(recipe_history.errors[:rating]).to be_present
+      end
+
+      it 'rejects string ratings' do
+        recipe_history = build(:recipe_history, rating: 'good')
+        expect(recipe_history).not_to be_valid
+        expect(recipe_history.errors[:rating]).to be_present
+      end
+    end
+  end
+
+  describe 'scopes' do
+    let!(:recent_history) { create(:recipe_history, cooked_at: 1.day.ago) }
+    let!(:old_history) { create(:recipe_history, cooked_at: 1.week.ago) }
+    let!(:rated_history) { create(:recipe_history, :rated) }
+    let!(:unrated_history) { create(:recipe_history, rating: nil) }
+
+    describe '.recent' do
+      it 'orders by cooked_at desc' do
+        expect(RecipeHistory.recent.first).to eq(recent_history)
+      end
+    end
+
+    describe '.rated' do
+      it 'returns only rated histories' do
+        expect(RecipeHistory.rated).to include(rated_history)
+        expect(RecipeHistory.rated).not_to include(unrated_history)
+      end
+    end
+
+    describe '.unrated' do
+      it 'returns only unrated histories' do
+        expect(RecipeHistory.unrated).to include(unrated_history)
+        expect(RecipeHistory.unrated).not_to include(rated_history)
+      end
+    end
+
+    describe '.by_user' do
+      it 'filters by user_id' do
+        expect(RecipeHistory.by_user(recent_history.user_id)).to include(recent_history)
+      end
+    end
+
+    describe '.by_recipe' do
+      it 'filters by recipe_id' do
+        expect(RecipeHistory.by_recipe(recent_history.recipe_id)).to include(recent_history)
+      end
+    end
+  end
+
+  describe 'constants' do
+    it 'defines RATING_RANGE' do
+      expect(RecipeHistory::RATING_RANGE).to eq(1..5)
+    end
+  end
+
+  describe 'instance methods' do
+    let(:recipe_history) { create(:recipe_history, cooked_at: Time.zone.parse('2025-01-15 14:30:00')) }
+
+    describe '#cooked_date' do
+      it 'returns formatted date in Japanese' do
+        expect(recipe_history.cooked_date).to eq('2025年01月15日')
+      end
+    end
+
+    describe '#cooked_time' do
+      it 'returns formatted time' do
+        expect(recipe_history.cooked_time).to eq('14:30')
+      end
+    end
+  end
+end

--- a/backend/spec/models/recipe_history_spec.rb
+++ b/backend/spec/models/recipe_history_spec.rb
@@ -61,7 +61,9 @@ RSpec.describe RecipeHistory, type: :model do
 
     describe '.recent' do
       it 'orders by cooked_at desc' do
-        expect(RecipeHistory.recent.first).to eq(recent_history)
+        histories = [recent_history, old_history]
+        recent_ordered = RecipeHistory.where(id: histories.map(&:id)).recent
+        expect(recent_ordered.first).to eq(recent_history)
       end
     end
 

--- a/liff/src/types/recipe.ts
+++ b/liff/src/types/recipe.ts
@@ -25,6 +25,7 @@ export interface RecipeHistory {
   recipe_id: number
   cooked_at: string
   memo: string | null
+  rating?: number | null
   created_at: string
   updated_at: string
   recipe?: {
@@ -38,7 +39,12 @@ export interface RecipeHistory {
 export interface CreateRecipeHistoryParams {
   recipe_id: number
   memo?: string
+  rating?: number | null
   cooked_at?: string
+}
+
+export interface UpdateRecipeHistoryParams {
+  rating?: number | null
 }
 
 // チェックボックス用のローカル状態


### PR DESCRIPTION
## 概要

  Issue #38 RecipeHistoryモデルにrating（評価）機能を追加し、ユーザーがレシピに1-5の評価を付けられるようにした。


  ### 実装内容

  #### データベース設計
  - ratingカラム追加（integer型、1-5の範囲、nullable）
  - DBレベルのチェック制約追加（rating BETWEEN 1 AND 5）
  - パフォーマンス向上のための複合インデックス追加（user_id, cooked_at）

  #### モデル更新
  - バリデーション追加（1-5の整数、nil許可）
  - 新しいスコープ追加（rated, unrated）
  - 定数RATING_RANGE追加でテストとモデルでの共有

  #### API拡張
  - GET /api/v1/recipe_histories/:id - 個別のレシピ履歴取得
  - PATCH /api/v1/recipe_histories/:id - rating更新専用エンドポイント
  - セキュリティ強化（current_user.recipe_histories.find でユーザー境界担保）
  - 既存APIのレスポンスにratingフィールド追加

  ### 編集ファイル

  #### バックエンド
  - `backend/db/migrate/20250908064315_add_rating_to_recipe_histories.rb`
  - `backend/db/migrate/20250908064416_add_index_to_recipe_histories_user_id_cooked_at.rb`
  - `backend/app/models/recipe_history.rb`
  - `backend/app/controllers/api/v1/recipe_histories_controller.rb`
  - `backend/config/routes.rb`
  - `backend/spec/models/recipe_history_spec.rb`
  - `backend/spec/requests/api/v1/recipe_histories_spec.rb`
  - `backend/spec/factories/recipe_histories.rb`

  #### フロントエンド（LIFF）
  - `liff/src/types/recipe.ts`