### PR TITLE
wrap-parameters修正

### DIFF
--- a/backend/app/controllers/api/v1/recipe_histories_controller.rb
+++ b/backend/app/controllers/api/v1/recipe_histories_controller.rb
@@ -2,8 +2,6 @@ class Api::V1::RecipeHistoriesController < ApplicationController
   before_action :authenticate_user!
   before_action :find_recipe_history, only: [ :show, :update, :destroy ]
   
-  # Configure parameter wrapping only for POST/PATCH actions  
-  wrap_parameters :recipe_history, include: [:recipe_id, :memo, :cooked_at, :rating]
 
   # GET /api/v1/recipe_histories
   # 常にcooked_atの降順（最新順）で返却
@@ -61,7 +59,7 @@ class Api::V1::RecipeHistoriesController < ApplicationController
       render json: {
         success: true,
         data: recipe_history_json(@recipe_history),
-        message: "調理記録を更新しました"
+        message: "評価を更新しました"
       }
     else
       render json: {

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -11,6 +11,7 @@ class ApplicationController < ActionController::API
   
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
   rescue_from ActiveRecord::RecordInvalid, with: :unprocessable_entity
+  rescue_from ActionController::ParameterMissing, with: :bad_request
 
   protected
 
@@ -34,6 +35,10 @@ class ApplicationController < ActionController::API
 
   def unprocessable_entity(exception)
     render json: { error: exception.record.errors.full_messages }, status: :unprocessable_entity
+  end
+
+  def bad_request(exception)
+    render json: { error: exception.message }, status: :bad_request
   end
 
   # DeviseのJWTで認証メソッドが正しく読み込まれない場合の手動実装

--- a/backend/spec/requests/api/v1/recipe_histories_spec.rb
+++ b/backend/spec/requests/api/v1/recipe_histories_spec.rb
@@ -188,6 +188,14 @@ RSpec.describe 'Api::V1::RecipeHistories', type: :request do
       post '/api/v1/recipe_histories', params: { recipe_history: { memo: 'x', cooked_at: Time.current.iso8601 } }, headers: headers, as: :json
       expect(response).to have_http_status(:unprocessable_entity)
     end
+
+    it 'フラットJSONでは400を返す（ParameterMissing）' do
+      headers = auth_header_for(user)
+      post '/api/v1/recipe_histories', params: { recipe_id: recipe.id, memo: 'フラット形式' }, headers: headers, as: :json
+      expect(response).to have_http_status(:bad_request)
+      body = JSON.parse(response.body)
+      expect(body['error']).to include('param is missing or the value is empty: recipe_history')
+    end
   end
 
   describe 'PATCH /api/v1/recipe_histories/:id' do


### PR DESCRIPTION
## 概要

  Api::V1::RecipeHistoriesControllerで局所的に再有効化されていたwrap_parametersを削除し、全コントローラで「ネスト必須」のJSONリクエスト形式に統一した。

  実装内容

  wrap_parameters一貫性修正
  - Api::V1::RecipeHistoriesControllerのwrap_parameters :recipe_history行を削除
  - ApplicationControllerのwrap_parameters false設定に全コントローラを統一
  - 全APIエンドポイントでネスト形式（{ recipe_history: {...} }）のリクエストが必須

  メッセージ統一
  - RecipeHistoriesController updateアクションの成功メッセージを「評価を更新しました」に変更
  - テスト期待値との整合性確保

  エラーハンドリング改善
  - ApplicationControllerにActionController::ParameterMissingの処理を追加
  - フラットJSONリクエスト時に適切な400エラーとJSON形式レスポンスを返却

  編集ファイル

  backend/app/controllers/api/v1/recipe_histories_controller.rb
  - wrap_parameters行削除（6行目）
  - updateメッセージ修正（「調理記録を更新しました」→「評価を更新しました」）

  backend/app/controllers/application_controller.rb
  - ActionController::ParameterMissingのrescue_from追加
  - bad_requestメソッド追加

  backend/spec/requests/api/v1/recipe_histories_spec.rb
  - フラットJSONで400エラーを返すテストケース追加