### PR TITLE
feature/issue 36 shopping lists liff

### DIFF
--- a/backend/app/controllers/api/v1/shopping_list_items_controller.rb
+++ b/backend/app/controllers/api/v1/shopping_list_items_controller.rb
@@ -35,7 +35,9 @@ class Api::V1::ShoppingListItemsController < ApplicationController
         item = @shopping_list.shopping_list_items.find(item_params[:id])
         
         if item.update(item_params.permit(:is_checked, :lock_version))
-          results << ShoppingListItemSerializer.new(item, include: [:ingredient]).serializable_hash
+          # JSON:API形式のdataを抽出してresultsに追加
+          serialized = ShoppingListItemSerializer.new(item, include: [:ingredient]).serializable_hash
+          results << serialized[:data]
         else
           errors << {
             id: item_params[:id],

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -51,12 +51,13 @@ Rails.application.routes.draw do
 
       # Shopping lists and items
       # 明示的にHTTPメソッドとアクションをマッピングしてルーティングの曖昧さを排除
-      get    'shopping_lists',          to: 'shopping_lists#index'
-      post   'shopping_lists',          to: 'shopping_lists#create'
-      get    'shopping_lists/:id',      to: 'shopping_lists#show'
-      patch  'shopping_lists/:id',      to: 'shopping_lists#update'
-      put    'shopping_lists/:id',      to: 'shopping_lists#update'
-      delete 'shopping_lists/:id',      to: 'shopping_lists#destroy'
+      get    'shopping_lists',             to: 'shopping_lists#index'
+      post   'shopping_lists',             to: 'shopping_lists#create'
+      get    'shopping_lists/:id',         to: 'shopping_lists#show'
+      patch  'shopping_lists/:id',         to: 'shopping_lists#update'
+      put    'shopping_lists/:id',         to: 'shopping_lists#update'
+      delete 'shopping_lists/:id',         to: 'shopping_lists#destroy'
+      patch  'shopping_lists/:id/complete', to: 'shopping_lists#complete'
 
       resources :shopping_lists, only: [] do
         resources :items, controller: 'shopping_list_items', only: [:update, :destroy] do

--- a/backend/spec/models/shopping_list_spec.rb
+++ b/backend/spec/models/shopping_list_spec.rb
@@ -148,8 +148,9 @@ RSpec.describe ShoppingList, type: :model do
       end
 
       context 'without title but with recipe' do
-        let(:recipe) { create(:recipe, title: 'カレー') }
-        let(:shopping_list) { create(:shopping_list, :with_recipe, recipe: recipe, title: nil) }
+        let(:user) { create(:user) }
+        let(:recipe) { create(:recipe, title: 'カレー', user: user) }
+        let(:shopping_list) { create(:shopping_list, :with_recipe, recipe: recipe, user: user, title: nil) }
 
         it 'returns recipe-based title' do
           expect(shopping_list.display_title).to eq('カレーの買い物リスト')

--- a/liff/src/App.tsx
+++ b/liff/src/App.tsx
@@ -7,6 +7,8 @@ import RecipeHistory from './pages/RecipeHistory/RecipeHistory'
 import Settings from './pages/Settings/Settings'
 import RecipeList from './pages/Recipes/RecipeList'
 import RecipeDetail from './pages/Recipes/RecipeDetail'
+import ShoppingLists from './pages/ShoppingLists/ShoppingLists'
+import ShoppingListDetail from './pages/ShoppingLists/ShoppingListDetail'
 
 function App() {
   return (
@@ -19,6 +21,8 @@ function App() {
             <Route path="/recipes" element={<RecipeList />} />
             <Route path="/recipes/:id" element={<RecipeDetail />} />
             <Route path="/recipe-history" element={<RecipeHistory />} />
+            <Route path="/shopping-lists" element={<ShoppingLists />} />
+            <Route path="/shopping-lists/:id" element={<ShoppingListDetail />} />
             <Route path="/settings" element={<Settings />} />
           </Route>
         </Routes>

--- a/liff/src/api/shoppingLists.ts
+++ b/liff/src/api/shoppingLists.ts
@@ -3,10 +3,7 @@ import type {
   ShoppingList,
   ShoppingListItem,
   ShoppingListSummary,
-  Recipe,
-  Ingredient,
   JsonApiResource,
-  JsonApiResponse,
   ShoppingListsResponse,
   ShoppingListResponse,
   GetShoppingListsParams,
@@ -16,8 +13,8 @@ import type {
 } from '../types/shoppingList'
 
 // JSON:API正規化ユーティリティ
-function normalizeJsonApiResource(resource: JsonApiResource, included: JsonApiResource[] = []): any {
-  const normalized = {
+function normalizeJsonApiResource(resource: JsonApiResource, included: JsonApiResource[] = []): Record<string, any> {
+  const normalized: Record<string, any> = {
     id: Number(resource.id),
     ...convertKeysFromSnakeCase(resource.attributes)
   }
@@ -122,8 +119,11 @@ export async function updateShoppingListItem(
   }
 ): Promise<ShoppingListItem> {
   const requestBody: UpdateShoppingListItemRequest = {
-    shopping_list_item: {
-      ...convertKeysToSnakeCase(updates)
+    shopping_list_item: convertKeysToSnakeCase(updates) as {
+      quantity?: number
+      unit?: string
+      is_checked?: boolean
+      lock_version: number
     }
   }
 
@@ -151,7 +151,11 @@ export async function bulkUpdateShoppingListItems(
   }>
 ): Promise<ShoppingListItem[]> {
   const requestBody: BulkUpdateShoppingListItemsRequest = {
-    items: items.map(item => convertKeysToSnakeCase(item))
+    items: items.map(item => convertKeysToSnakeCase(item) as {
+      id: number
+      is_checked: boolean
+      lock_version: number
+    })
   }
 
   const response = await apiClient.patch<BulkUpdateShoppingListItemsResponse>(

--- a/liff/src/api/shoppingLists.ts
+++ b/liff/src/api/shoppingLists.ts
@@ -1,0 +1,217 @@
+import { apiClient } from './client'
+import type {
+  ShoppingList,
+  ShoppingListItem,
+  ShoppingListSummary,
+  Recipe,
+  Ingredient,
+  JsonApiResource,
+  JsonApiResponse,
+  ShoppingListsResponse,
+  ShoppingListResponse,
+  GetShoppingListsParams,
+  UpdateShoppingListItemRequest,
+  BulkUpdateShoppingListItemsRequest,
+  BulkUpdateShoppingListItemsResponse
+} from '../types/shoppingList'
+
+// JSON:API正規化ユーティリティ
+function normalizeJsonApiResource(resource: JsonApiResource, included: JsonApiResource[] = []): any {
+  const normalized = {
+    id: Number(resource.id),
+    ...convertKeysFromSnakeCase(resource.attributes)
+  }
+
+  // リレーションシップの処理
+  if (resource.relationships) {
+    Object.entries(resource.relationships).forEach(([key, relationship]: [string, any]) => {
+      if (relationship.data) {
+        if (Array.isArray(relationship.data)) {
+          // 複数のリレーション
+          normalized[convertKeyFromSnakeCase(key)] = relationship.data
+            .map((rel: any) => findIncludedResource(rel.type, rel.id, included))
+            .filter(Boolean)
+            .map((res: JsonApiResource) => normalizeJsonApiResource(res, included))
+        } else {
+          // 単一のリレーション
+          const relatedResource = findIncludedResource(
+            relationship.data.type,
+            relationship.data.id,
+            included
+          )
+          if (relatedResource) {
+            normalized[convertKeyFromSnakeCase(key)] = normalizeJsonApiResource(relatedResource, included)
+          }
+        }
+      }
+    })
+  }
+
+  return normalized
+}
+
+function findIncludedResource(type: string, id: string, included: JsonApiResource[]): JsonApiResource | null {
+  return included.find(res => res.type === type && res.id === id) || null
+}
+
+function convertKeysFromSnakeCase(obj: Record<string, any>): Record<string, any> {
+  const result: Record<string, any> = {}
+  Object.entries(obj).forEach(([key, value]) => {
+    result[convertKeyFromSnakeCase(key)] = value
+  })
+  return result
+}
+
+function convertKeyFromSnakeCase(key: string): string {
+  return key.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase())
+}
+
+function convertKeysToSnakeCase(obj: Record<string, any>): Record<string, any> {
+  const result: Record<string, any> = {}
+  Object.entries(obj).forEach(([key, value]) => {
+    result[convertKeyToSnakeCase(key)] = value
+  })
+  return result
+}
+
+function convertKeyToSnakeCase(key: string): string {
+  return key.replace(/([A-Z])/g, '_$1').toLowerCase()
+}
+
+// API関数群
+
+/**
+ * 買い物リスト一覧を取得
+ */
+export async function getShoppingLists(params: GetShoppingListsParams = {}): Promise<ShoppingListSummary[]> {
+  const response = await apiClient.get<ShoppingListsResponse>('/shopping_lists', { params })
+  
+  if (!Array.isArray(response.data.data)) {
+    return []
+  }
+
+  return response.data.data.map(resource => 
+    normalizeJsonApiResource(resource, response.data.included || [])
+  ) as ShoppingListSummary[]
+}
+
+/**
+ * 買い物リスト詳細を取得
+ */
+export async function getShoppingList(id: number): Promise<ShoppingList> {
+  const response = await apiClient.get<ShoppingListResponse>(`/shopping_lists/${id}`)
+  
+  if (Array.isArray(response.data.data)) {
+    throw new Error('Expected single resource, got array')
+  }
+
+  return normalizeJsonApiResource(response.data.data, response.data.included || []) as ShoppingList
+}
+
+/**
+ * 買い物リストアイテムを更新
+ */
+export async function updateShoppingListItem(
+  shoppingListId: number,
+  itemId: number,
+  updates: {
+    quantity?: number
+    unit?: string
+    isChecked?: boolean
+    lockVersion: number
+  }
+): Promise<ShoppingListItem> {
+  const requestBody: UpdateShoppingListItemRequest = {
+    shopping_list_item: {
+      ...convertKeysToSnakeCase(updates)
+    }
+  }
+
+  const response = await apiClient.patch<ShoppingListResponse>(
+    `/shopping_lists/${shoppingListId}/items/${itemId}`,
+    requestBody
+  )
+
+  if (Array.isArray(response.data.data)) {
+    throw new Error('Expected single resource, got array')
+  }
+
+  return normalizeJsonApiResource(response.data.data, response.data.included || []) as ShoppingListItem
+}
+
+/**
+ * 買い物リストアイテムを一括更新
+ */
+export async function bulkUpdateShoppingListItems(
+  shoppingListId: number,
+  items: Array<{
+    id: number
+    isChecked: boolean
+    lockVersion: number
+  }>
+): Promise<ShoppingListItem[]> {
+  const requestBody: BulkUpdateShoppingListItemsRequest = {
+    items: items.map(item => convertKeysToSnakeCase(item))
+  }
+
+  const response = await apiClient.patch<BulkUpdateShoppingListItemsResponse>(
+    `/shopping_lists/${shoppingListId}/items/bulk_update`,
+    requestBody
+  )
+
+  if (response.data.errors) {
+    throw new Error(response.data.errors[0]?.detail || 'Bulk update failed')
+  }
+
+  if (!response.data.data) {
+    return []
+  }
+
+  return response.data.data.map(resource => 
+    normalizeJsonApiResource(resource, [])
+  ) as ShoppingListItem[]
+}
+
+/**
+ * 買い物リストを完了状態にする
+ */
+export async function completeShoppingList(id: number): Promise<ShoppingList> {
+  const response = await apiClient.patch<ShoppingListResponse>(`/shopping_lists/${id}/complete`)
+  
+  if (Array.isArray(response.data.data)) {
+    throw new Error('Expected single resource, got array')
+  }
+
+  return normalizeJsonApiResource(response.data.data, response.data.included || []) as ShoppingList
+}
+
+/**
+ * 買い物リストを削除
+ */
+export async function deleteShoppingList(id: number): Promise<void> {
+  await apiClient.delete(`/shopping_lists/${id}`)
+}
+
+/**
+ * 買い物リストを更新（ステータス、タイトル、ノートなど）
+ */
+export async function updateShoppingList(
+  id: number,
+  updates: {
+    status?: 'pending' | 'in_progress' | 'completed'
+    title?: string
+    note?: string
+  }
+): Promise<ShoppingList> {
+  const requestBody = {
+    shopping_list: convertKeysToSnakeCase(updates)
+  }
+
+  const response = await apiClient.patch<ShoppingListResponse>(`/shopping_lists/${id}`, requestBody)
+  
+  if (Array.isArray(response.data.data)) {
+    throw new Error('Expected single resource, got array')
+  }
+
+  return normalizeJsonApiResource(response.data.data, response.data.included || []) as ShoppingList
+}

--- a/liff/src/pages/ShoppingLists/ShoppingListDetail.tsx
+++ b/liff/src/pages/ShoppingLists/ShoppingListDetail.tsx
@@ -1,0 +1,338 @@
+import React, { useEffect, useState } from 'react'
+import { useParams, useNavigate, Link } from 'react-router-dom'
+import type { ShoppingList, ShoppingListItem } from '../../types/shoppingList'
+import {
+  getShoppingList,
+  updateShoppingListItem,
+  completeShoppingList
+} from '../../api/shoppingLists'
+
+const ShoppingListDetail: React.FC = () => {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const [shoppingList, setShoppingList] = useState<ShoppingList | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [updatingItems, setUpdatingItems] = useState<Set<number>>(new Set())
+  const [completing, setCompleting] = useState(false)
+
+  const fetchShoppingList = async () => {
+    if (!id) return
+
+    setLoading(true)
+    setError(null)
+    try {
+      const list = await getShoppingList(Number(id))
+      setShoppingList(list)
+    } catch (e) {
+      console.error(e)
+      setError('買い物リストの取得に失敗しました。')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchShoppingList()
+  }, [id])
+
+  const handleItemCheck = async (item: ShoppingListItem, checked: boolean) => {
+    if (!shoppingList || updatingItems.has(item.id)) return
+
+    // 楽観的更新: UIを即座に更新
+    const optimisticItems = shoppingList.shoppingListItems?.map(i =>
+      i.id === item.id
+        ? {
+            ...i,
+            isChecked: checked,
+            checkedAt: checked ? new Date().toISOString() : null
+          }
+        : i
+    ) || []
+
+    setShoppingList(prev => prev ? {
+      ...prev,
+      shoppingListItems: optimisticItems,
+      // 進捗も即座に更新
+      completionPercentage: calculateCompletionPercentage(optimisticItems),
+      uncheckedItemsCount: optimisticItems.filter(i => !i.isChecked).length,
+      canBeCompleted: optimisticItems.every(i => i.isChecked) && optimisticItems.length > 0
+    } : null)
+
+    setUpdatingItems(prev => new Set([...prev, item.id]))
+
+    try {
+      const updatedItem = await updateShoppingListItem(
+        shoppingList.id,
+        item.id,
+        {
+          isChecked: checked,
+          lockVersion: item.lockVersion
+        }
+      )
+
+      // サーバーからの正確な値で更新
+      setShoppingList(prev => {
+        if (!prev) return null
+        const serverItems = prev.shoppingListItems?.map(i =>
+          i.id === updatedItem.id ? updatedItem : i
+        ) || []
+        
+        return {
+          ...prev,
+          shoppingListItems: serverItems,
+          completionPercentage: calculateCompletionPercentage(serverItems),
+          uncheckedItemsCount: serverItems.filter(i => !i.isChecked).length,
+          canBeCompleted: serverItems.every(i => i.isChecked) && serverItems.length > 0
+        }
+      })
+    } catch (e: any) {
+      console.error(e)
+      
+      // エラー時のロールバック
+      const originalItems = shoppingList.shoppingListItems?.map(i =>
+        i.id === item.id ? item : i
+      ) || []
+
+      setShoppingList(prev => prev ? {
+        ...prev,
+        shoppingListItems: originalItems,
+        completionPercentage: calculateCompletionPercentage(originalItems),
+        uncheckedItemsCount: originalItems.filter(i => !i.isChecked).length,
+        canBeCompleted: originalItems.every(i => i.isChecked) && originalItems.length > 0
+      } : null)
+
+      // 409エラー（楽観的ロック）の場合は再取得を促す
+      if (e.response?.status === 409) {
+        setError('他のユーザーによって更新されています。画面を再読み込みして最新の状態を確認してください。')
+      } else {
+        setError('アイテムの更新に失敗しました。')
+      }
+    } finally {
+      setUpdatingItems(prev => {
+        const next = new Set(prev)
+        next.delete(item.id)
+        return next
+      })
+    }
+  }
+
+  const handleComplete = async () => {
+    if (!shoppingList || completing) return
+
+    setCompleting(true)
+    setError(null)
+
+    try {
+      const completedList = await completeShoppingList(shoppingList.id)
+      setShoppingList(completedList)
+      
+      // 完了したら一覧に戻る
+      setTimeout(() => {
+        navigate('/shopping-lists')
+      }, 1500)
+    } catch (e) {
+      console.error(e)
+      setError('完了処理に失敗しました。')
+    } finally {
+      setCompleting(false)
+    }
+  }
+
+  const calculateCompletionPercentage = (items: ShoppingListItem[]): number => {
+    if (items.length === 0) return 0
+    const checkedCount = items.filter(item => item.isChecked).length
+    return Math.round((checkedCount / items.length) * 100)
+  }
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString)
+    return date.toLocaleDateString('ja-JP', {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    })
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-100 flex items-center justify-center">
+        <p className="text-gray-600">読み込み中...</p>
+      </div>
+    )
+  }
+
+  if (!shoppingList) {
+    return (
+      <div className="min-h-screen bg-gray-100 flex items-center justify-center">
+        <div className="text-center">
+          <p className="text-gray-600 mb-4">買い物リストが見つかりません</p>
+          <Link
+            to="/shopping-lists"
+            className="text-blue-600 hover:text-blue-800 underline"
+          >
+            一覧に戻る
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-100">
+      <div className="container mx-auto px-4 py-8">
+        <div className="mb-6">
+          <Link
+            to="/shopping-lists"
+            className="text-blue-600 hover:text-blue-800 text-sm mb-2 inline-block"
+          >
+            ← 一覧に戻る
+          </Link>
+          <h1 className="text-2xl font-bold text-gray-800">
+            {shoppingList.displayTitle}
+          </h1>
+          {shoppingList.recipe && (
+            <p className="text-gray-600 mt-1">
+              レシピ: {shoppingList.recipe.title}
+            </p>
+          )}
+        </div>
+
+        <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+          {error && (
+            <div className="mb-4 p-3 rounded bg-red-50 text-red-700 border border-red-200">
+              {error}
+              <button
+                onClick={fetchShoppingList}
+                className="ml-2 text-red-800 underline hover:no-underline"
+              >
+                再読み込み
+              </button>
+            </div>
+          )}
+
+          {/* 進捗表示 */}
+          <div className="mb-6">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-sm font-medium text-gray-700">
+                進捗: {shoppingList.totalItemsCount - shoppingList.uncheckedItemsCount} / {shoppingList.totalItemsCount} 項目
+              </span>
+              <span className="text-sm font-medium text-gray-700">
+                {shoppingList.completionPercentage}%
+              </span>
+            </div>
+            <div className="w-full bg-gray-200 rounded-full h-3">
+              <div
+                className="bg-blue-500 h-3 rounded-full transition-all duration-300"
+                style={{ width: `${shoppingList.completionPercentage}%` }}
+              />
+            </div>
+          </div>
+
+          {/* 完了ボタン */}
+          {shoppingList.canBeCompleted && shoppingList.status !== 'completed' && (
+            <div className="mb-6">
+              <button
+                onClick={handleComplete}
+                disabled={completing}
+                className="w-full bg-green-600 hover:bg-green-700 disabled:bg-gray-400 text-white font-medium py-3 px-4 rounded-lg transition-colors"
+              >
+                {completing ? '完了処理中...' : '買い物完了'}
+              </button>
+            </div>
+          )}
+
+          {/* アイテムリスト */}
+          <div className="space-y-3">
+            {shoppingList.shoppingListItems?.map((item) => (
+              <div
+                key={item.id}
+                className={`flex items-center p-3 border rounded-lg transition-colors ${
+                  item.isChecked
+                    ? 'bg-green-50 border-green-200'
+                    : 'bg-white border-gray-200'
+                }`}
+              >
+                <div className="flex items-center flex-1">
+                  <input
+                    type="checkbox"
+                    checked={item.isChecked}
+                    onChange={(e) => handleItemCheck(item, e.target.checked)}
+                    disabled={updatingItems.has(item.id)}
+                    className="h-5 w-5 text-blue-600 rounded focus:ring-blue-500 mr-3"
+                  />
+                  <div className="flex-1">
+                    <span
+                      className={`font-medium ${
+                        item.isChecked
+                          ? 'text-green-800 line-through'
+                          : 'text-gray-900'
+                      }`}
+                    >
+                      {item.ingredient?.displayName || item.ingredient?.name || '不明な食材'}
+                    </span>
+                    <div className="text-sm text-gray-600 mt-1">
+                      <span>{item.displayQuantityWithUnit}</span>
+                      {item.ingredient?.category && (
+                        <span className="ml-2 px-2 py-1 bg-gray-100 text-gray-700 rounded text-xs">
+                          {item.ingredient.category}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+                {updatingItems.has(item.id) && (
+                  <div className="ml-2">
+                    <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-blue-600" />
+                  </div>
+                )}
+                {item.checkedAt && (
+                  <div className="ml-2 text-xs text-gray-500">
+                    {formatDate(item.checkedAt)}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+
+          {/* 完了済みの場合のメッセージ */}
+          {shoppingList.status === 'completed' && (
+            <div className="mt-6 p-4 bg-green-50 border border-green-200 rounded-lg">
+              <p className="text-green-800 font-medium text-center">
+                🎉 買い物が完了しました！
+              </p>
+            </div>
+          )}
+        </div>
+
+        {/* メタ情報 */}
+        <div className="bg-white rounded-lg shadow-md p-6">
+          <h3 className="font-medium text-gray-900 mb-3">詳細情報</h3>
+          <div className="grid grid-cols-1 gap-3 text-sm">
+            <div className="flex justify-between">
+              <span className="text-gray-600">ステータス:</span>
+              <span className="font-medium">{shoppingList.statusDisplay}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-600">作成日:</span>
+              <span>{formatDate(shoppingList.createdAt)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-600">更新日:</span>
+              <span>{formatDate(shoppingList.updatedAt)}</span>
+            </div>
+            {shoppingList.note && (
+              <div>
+                <span className="text-gray-600 block mb-1">メモ:</span>
+                <p className="text-gray-900">{shoppingList.note}</p>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ShoppingListDetail

--- a/liff/src/pages/ShoppingLists/ShoppingListDetail.tsx
+++ b/liff/src/pages/ShoppingLists/ShoppingListDetail.tsx
@@ -270,7 +270,7 @@ const ShoppingListDetail: React.FC = () => {
                           : 'text-gray-900'
                       }`}
                     >
-                      {item.ingredient?.displayName || item.ingredient?.name || '不明な食材'}
+                      {item.ingredient?.displayNameWithEmoji || item.ingredient?.displayName || item.ingredient?.name || '不明な食材'}
                     </span>
                     <div className="text-sm text-gray-600 mt-1">
                       <span>{item.displayQuantityWithUnit}</span>

--- a/liff/src/pages/ShoppingLists/ShoppingLists.tsx
+++ b/liff/src/pages/ShoppingLists/ShoppingLists.tsx
@@ -1,0 +1,163 @@
+import React, { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import type { ShoppingListSummary } from '../../types/shoppingList'
+import { getShoppingLists } from '../../api/shoppingLists'
+
+const ShoppingLists: React.FC = () => {
+  const [shoppingLists, setShoppingLists] = useState<ShoppingListSummary[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchShoppingLists = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      // 未完了・進行中のリストを取得
+      const activeStatuses = ['pending', 'in_progress'] as const
+      const allLists = await Promise.all(
+        activeStatuses.map(status => getShoppingLists({ status }))
+      )
+      
+      // 結果をマージして作成日時でソート
+      const mergedLists = allLists.flat().sort((a, b) => 
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      )
+      
+      setShoppingLists(mergedLists)
+    } catch (e) {
+      console.error(e)
+      setError('買い物リストの取得に失敗しました。通信環境をご確認ください。')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchShoppingLists()
+  }, [])
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'pending':
+        return 'bg-gray-100 text-gray-800'
+      case 'in_progress':
+        return 'bg-blue-100 text-blue-800'
+      case 'completed':
+        return 'bg-green-100 text-green-800'
+      default:
+        return 'bg-gray-100 text-gray-800'
+    }
+  }
+
+  const getProgressBarColor = (percentage: number) => {
+    if (percentage === 0) return 'bg-gray-300'
+    if (percentage < 50) return 'bg-red-400'
+    if (percentage < 100) return 'bg-yellow-400'
+    return 'bg-green-400'
+  }
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString)
+    return date.toLocaleDateString('ja-JP', {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    })
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-100">
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-2xl font-bold text-gray-800 mb-6">買い物リスト</h1>
+
+        <div className="bg-white rounded-lg shadow-md p-6">
+          {loading && (
+            <div className="text-center py-8">
+              <p className="text-gray-600">読み込み中...</p>
+            </div>
+          )}
+
+          {!loading && error && (
+            <div className="mb-4 p-3 rounded bg-red-50 text-red-700 border border-red-200">
+              {error}
+              <button
+                onClick={fetchShoppingLists}
+                className="ml-2 text-red-800 underline hover:no-underline"
+              >
+                再試行
+              </button>
+            </div>
+          )}
+
+          {!loading && !error && shoppingLists.length === 0 && (
+            <div className="text-center py-8">
+              <p className="text-gray-600 mb-4">買い物リストがありません</p>
+              <p className="text-sm text-gray-500">
+                レシピから買い物リストを作成してみましょう
+              </p>
+            </div>
+          )}
+
+          {!loading && !error && shoppingLists.length > 0 && (
+            <div className="space-y-4">
+              {shoppingLists.map((list) => (
+                <Link
+                  key={list.id}
+                  to={`/shopping-lists/${list.id}`}
+                  className="block border border-gray-200 rounded-lg p-4 hover:bg-gray-50 hover:border-gray-300 transition-colors"
+                >
+                  <div className="flex items-start justify-between mb-3">
+                    <div className="flex-1">
+                      <h3 className="font-medium text-gray-900 mb-1">
+                        {list.displayTitle}
+                      </h3>
+                      {list.recipe && (
+                        <p className="text-sm text-gray-600">
+                          レシピ: {list.recipe.title}
+                        </p>
+                      )}
+                    </div>
+                    <span
+                      className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(
+                        list.status
+                      )}`}
+                    >
+                      {list.statusDisplay}
+                    </span>
+                  </div>
+
+                  <div className="mb-3">
+                    <div className="flex items-center justify-between text-sm text-gray-600 mb-1">
+                      <span>進捗: {list.totalItemsCount - list.uncheckedItemsCount} / {list.totalItemsCount} 項目</span>
+                      <span>{list.completionPercentage}%</span>
+                    </div>
+                    <div className="w-full bg-gray-200 rounded-full h-2">
+                      <div
+                        className={`h-2 rounded-full transition-all duration-300 ${getProgressBarColor(
+                          list.completionPercentage
+                        )}`}
+                        style={{ width: `${list.completionPercentage}%` }}
+                      />
+                    </div>
+                  </div>
+
+                  <div className="flex items-center justify-between text-sm text-gray-500">
+                    <span>作成日: {formatDate(list.createdAt)}</span>
+                    {list.canBeCompleted && (
+                      <span className="text-green-600 font-medium">
+                        完了可能
+                      </span>
+                    )}
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ShoppingLists

--- a/liff/src/types/shoppingList.ts
+++ b/liff/src/types/shoppingList.ts
@@ -1,0 +1,139 @@
+// 基本的な買い物リスト型
+export interface ShoppingList {
+  id: number
+  userId: number
+  recipeId: number | null
+  title: string | null
+  note: string | null
+  status: 'pending' | 'in_progress' | 'completed'
+  statusDisplay: string
+  displayTitle: string
+  completionPercentage: number
+  totalItemsCount: number
+  uncheckedItemsCount: number
+  canBeCompleted: boolean
+  createdAt: string
+  updatedAt: string
+  recipe?: Recipe | null
+  shoppingListItems?: ShoppingListItem[]
+}
+
+// 買い物リストアイテム型
+export interface ShoppingListItem {
+  id: number
+  shoppingListId: number
+  ingredientId: number
+  quantity: number
+  unit: string | null
+  isChecked: boolean
+  checkedAt: string | null
+  lockVersion: number
+  displayQuantityWithUnit: string
+  createdAt: string
+  updatedAt: string
+  ingredient?: Ingredient
+}
+
+// レシピ型（簡易版）
+export interface Recipe {
+  id: number
+  title: string
+  description: string | null
+  servings: number | null
+}
+
+// 食材型（簡易版）
+export interface Ingredient {
+  id: number
+  name: string
+  category: string
+  displayName: string
+}
+
+// JSON:API レスポンス型
+export interface JsonApiResource {
+  id: string
+  type: string
+  attributes: Record<string, any>
+  relationships?: Record<string, any>
+}
+
+export interface JsonApiResponse<T = JsonApiResource> {
+  data: T | T[]
+  included?: JsonApiResource[]
+  meta?: Record<string, any>
+  links?: Record<string, any>
+}
+
+// 一覧取得時のレスポンス型
+export interface ShoppingListsResponse extends JsonApiResponse<JsonApiResource[]> {
+  data: JsonApiResource[]
+}
+
+// 詳細取得時のレスポンス型
+export interface ShoppingListResponse extends JsonApiResponse<JsonApiResource> {
+  data: JsonApiResource
+}
+
+// API リクエスト/レスポンス型
+export interface GetShoppingListsParams {
+  page?: number
+  per_page?: number
+  status?: 'pending' | 'in_progress' | 'completed'
+  recipe_id?: number
+}
+
+export interface UpdateShoppingListItemRequest {
+  shopping_list_item: {
+    quantity?: number
+    unit?: string
+    is_checked?: boolean
+    lock_version: number
+  }
+}
+
+export interface BulkUpdateShoppingListItemsRequest {
+  items: Array<{
+    id: number
+    is_checked: boolean
+    lock_version: number
+  }>
+}
+
+export interface BulkUpdateShoppingListItemsResponse {
+  data?: JsonApiResource[]
+  errors?: Array<{
+    detail: string
+  }>
+  item_errors?: Array<{
+    id: number
+    errors: Array<{
+      detail: string
+    }>
+  }>
+}
+
+// エラーレスポンス型
+export interface ApiError {
+  errors: Array<{
+    detail: string
+    source?: Record<string, any>
+  }>
+}
+
+// 買い物リスト一覧用の型（正規化後）
+export interface ShoppingListSummary {
+  id: number
+  displayTitle: string
+  status: 'pending' | 'in_progress' | 'completed'
+  statusDisplay: string
+  completionPercentage: number
+  totalItemsCount: number
+  uncheckedItemsCount: number
+  canBeCompleted: boolean
+  createdAt: string
+  recipe?: {
+    id: number
+    title: string
+  } | null
+}

--- a/liff/src/types/shoppingList.ts
+++ b/liff/src/types/shoppingList.ts
@@ -1,8 +1,8 @@
 // 基本的な買い物リスト型
 export interface ShoppingList {
   id: number
-  userId: number
-  recipeId: number | null
+  userId?: number
+  recipeId?: number | null
   title: string | null
   note: string | null
   status: 'pending' | 'in_progress' | 'completed'
@@ -21,8 +21,8 @@ export interface ShoppingList {
 // 買い物リストアイテム型
 export interface ShoppingListItem {
   id: number
-  shoppingListId: number
-  ingredientId: number
+  shoppingListId?: number
+  ingredientId?: number
   quantity: number
   unit: string | null
   isChecked: boolean
@@ -47,7 +47,8 @@ export interface Ingredient {
   id: number
   name: string
   category: string
-  displayName: string
+  displayName?: string
+  displayNameWithEmoji?: string
 }
 
 // JSON:API レスポンス型

--- a/liff/test/shoppingLists.test.ts
+++ b/liff/test/shoppingLists.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  getShoppingLists,
+  getShoppingList,
+  updateShoppingListItem,
+  bulkUpdateShoppingListItems,
+  completeShoppingList
+} from '../src/api/shoppingLists'
+import type {
+  ShoppingListsResponse,
+  ShoppingListResponse,
+  JsonApiResource
+} from '../src/types/shoppingList'
+
+// APIクライアントのモック
+vi.mock('../src/api/client', () => ({
+  apiClient: {
+    get: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn()
+  }
+}))
+
+// モック化されたAPIクライアントを取得
+const { apiClient } = await import('../src/api/client')
+const mockApiClient = vi.mocked(apiClient)
+
+describe('ShoppingLists API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('getShoppingLists', () => {
+    it('買い物リスト一覧を正規化して返す', async () => {
+      const mockResponse: ShoppingListsResponse = {
+        data: [
+          {
+            id: '1',
+            type: 'shopping_list',
+            attributes: {
+              title: 'テスト買い物リスト',
+              status: 'pending',
+              status_display: '未開始',
+              display_title: 'テスト買い物リスト',
+              completion_percentage: 50,
+              total_items_count: 4,
+              unchecked_items_count: 2,
+              can_be_completed: false,
+              created_at: '2023-01-01T00:00:00Z',
+              updated_at: '2023-01-01T00:00:00Z'
+            }
+          }
+        ],
+        included: []
+      }
+
+      mockApiClient.get.mockResolvedValue({ data: mockResponse })
+
+      const result = await getShoppingLists()
+
+      expect(mockApiClient.get).toHaveBeenCalledWith('/shopping_lists', { params: {} })
+      expect(result).toHaveLength(1)
+      expect(result[0]).toEqual({
+        id: 1,
+        title: 'テスト買い物リスト',
+        status: 'pending',
+        statusDisplay: '未開始',
+        displayTitle: 'テスト買い物リスト',
+        completionPercentage: 50,
+        totalItemsCount: 4,
+        uncheckedItemsCount: 2,
+        canBeCompleted: false,
+        createdAt: '2023-01-01T00:00:00Z',
+        updatedAt: '2023-01-01T00:00:00Z'
+      })
+    })
+
+    it('パラメータを適切に渡す', async () => {
+      const mockResponse: ShoppingListsResponse = { data: [] }
+      mockApiClient.get.mockResolvedValue({ data: mockResponse })
+
+      await getShoppingLists({
+        page: 2,
+        per_page: 10,
+        status: 'pending'
+      })
+
+      expect(mockApiClient.get).toHaveBeenCalledWith('/shopping_lists', {
+        params: {
+          page: 2,
+          per_page: 10,
+          status: 'pending'
+        }
+      })
+    })
+  })
+
+  describe('getShoppingList', () => {
+    it('買い物リスト詳細を正規化して返す', async () => {
+      const mockResponse: ShoppingListResponse = {
+        data: {
+          id: '1',
+          type: 'shopping_list',
+          attributes: {
+            title: 'テスト買い物リスト',
+            status: 'pending',
+            status_display: '未開始',
+            display_title: 'テスト買い物リスト',
+            completion_percentage: 50,
+            total_items_count: 2,
+            unchecked_items_count: 1,
+            can_be_completed: false,
+            created_at: '2023-01-01T00:00:00Z',
+            updated_at: '2023-01-01T00:00:00Z'
+          },
+          relationships: {
+            shopping_list_items: {
+              data: [
+                { type: 'shopping_list_item', id: '1' }
+              ]
+            }
+          }
+        },
+        included: [
+          {
+            id: '1',
+            type: 'shopping_list_item',
+            attributes: {
+              quantity: 2,
+              unit: '個',
+              is_checked: false,
+              checked_at: null,
+              lock_version: 0,
+              display_quantity_with_unit: '2個',
+              created_at: '2023-01-01T00:00:00Z',
+              updated_at: '2023-01-01T00:00:00Z'
+            }
+          }
+        ]
+      }
+
+      mockApiClient.get.mockResolvedValue({ data: mockResponse })
+
+      const result = await getShoppingList(1)
+
+      expect(mockApiClient.get).toHaveBeenCalledWith('/shopping_lists/1')
+      expect(result.id).toBe(1)
+      expect(result.shoppingListItems).toHaveLength(1)
+      expect(result.shoppingListItems![0].id).toBe(1)
+      expect(result.shoppingListItems![0].isChecked).toBe(false)
+    })
+  })
+
+  describe('updateShoppingListItem', () => {
+    it('アイテムを更新して正規化した結果を返す', async () => {
+      const mockResponse: ShoppingListResponse = {
+        data: {
+          id: '1',
+          type: 'shopping_list_item',
+          attributes: {
+            quantity: 2,
+            unit: '個',
+            is_checked: true,
+            checked_at: '2023-01-01T01:00:00Z',
+            lock_version: 1,
+            display_quantity_with_unit: '2個',
+            created_at: '2023-01-01T00:00:00Z',
+            updated_at: '2023-01-01T01:00:00Z'
+          }
+        }
+      }
+
+      mockApiClient.patch.mockResolvedValue({ data: mockResponse })
+
+      const result = await updateShoppingListItem(1, 1, {
+        isChecked: true,
+        lockVersion: 0
+      })
+
+      expect(mockApiClient.patch).toHaveBeenCalledWith(
+        '/shopping_lists/1/items/1',
+        {
+          shopping_list_item: {
+            is_checked: true,
+            lock_version: 0
+          }
+        }
+      )
+      expect(result.id).toBe(1)
+      expect(result.isChecked).toBe(true)
+      expect(result.lockVersion).toBe(1)
+    })
+  })
+
+  describe('bulkUpdateShoppingListItems', () => {
+    it('複数アイテムを一括更新する', async () => {
+      const mockResponse = {
+        data: [
+          {
+            id: '1',
+            type: 'shopping_list_item',
+            attributes: {
+              quantity: 2,
+              unit: '個',
+              is_checked: true,
+              checked_at: '2023-01-01T01:00:00Z',
+              lock_version: 1,
+              display_quantity_with_unit: '2個',
+              created_at: '2023-01-01T00:00:00Z',
+              updated_at: '2023-01-01T01:00:00Z'
+            }
+          }
+        ]
+      }
+
+      mockApiClient.patch.mockResolvedValue({ data: mockResponse })
+
+      const result = await bulkUpdateShoppingListItems(1, [
+        { id: 1, isChecked: true, lockVersion: 0 }
+      ])
+
+      expect(mockApiClient.patch).toHaveBeenCalledWith(
+        '/shopping_lists/1/items/bulk_update',
+        {
+          items: [
+            { id: 1, is_checked: true, lock_version: 0 }
+          ]
+        }
+      )
+      expect(result).toHaveLength(1)
+      expect(result[0].isChecked).toBe(true)
+    })
+
+    it('エラーレスポンスの場合は例外を投げる', async () => {
+      const mockResponse = {
+        errors: [{ detail: 'Update failed' }]
+      }
+
+      mockApiClient.patch.mockResolvedValue({ data: mockResponse })
+
+      await expect(
+        bulkUpdateShoppingListItems(1, [
+          { id: 1, isChecked: true, lockVersion: 0 }
+        ])
+      ).rejects.toThrow('Update failed')
+    })
+  })
+
+  describe('completeShoppingList', () => {
+    it('買い物リストを完了状態にする', async () => {
+      const mockResponse: ShoppingListResponse = {
+        data: {
+          id: '1',
+          type: 'shopping_list',
+          attributes: {
+            title: 'テスト買い物リスト',
+            status: 'completed',
+            status_display: '完了',
+            display_title: 'テスト買い物リスト',
+            completion_percentage: 100,
+            total_items_count: 2,
+            unchecked_items_count: 0,
+            can_be_completed: true,
+            created_at: '2023-01-01T00:00:00Z',
+            updated_at: '2023-01-01T02:00:00Z'
+          }
+        }
+      }
+
+      mockApiClient.patch.mockResolvedValue({ data: mockResponse })
+
+      const result = await completeShoppingList(1)
+
+      expect(mockApiClient.patch).toHaveBeenCalledWith('/shopping_lists/1/complete')
+      expect(result.id).toBe(1)
+      expect(result.status).toBe('completed')
+      expect(result.completionPercentage).toBe(100)
+    })
+  })
+})


### PR DESCRIPTION
## 概要

  Issue: #36 LIFF版レコめしに買い物リスト管理機能を実装した。ユーザーは買い物リストの一覧確認、詳細画面でのアイテムチェック、買い物完了処理を行う。

 ### 実装内容

  バックエンドAPI拡張

  - 買い物リスト完了専用エンドポイントを追加（PATCH /api/v1/shopping_lists/:id/complete）
  - 未チェックアイテムの一括チェック処理をトランザクション内で実行
  - bulk_updateエンドポイントのレスポンス形状をJSON:API準拠に修正
  - 適切なHTTPステータスコード（409 Conflict）によるエラーハンドリング

  LIFF フロントエンド実装

  - 買い物リスト用の型定義を作成（JSON:API対応、楽観的ロック対応）
  - JSON:API正規化ユーティリティを含むAPIクライアントを実装
  - 買い物リスト一覧画面：進捗表示、ステータス別表示、完了可能状態の可視化
  - 買い物リスト詳細画面：楽観的更新、409エラー時の適切な処理、完了ボタン
  - 食材名表示の優先順位調整（displayNameWithEmoji優先）

  UX向上機能

  - チェック操作の即座のUI反映（楽観的更新）
  - 失敗時の自動ロールバック処理
  - 楽観的ロック競合時のユーザー向けメッセージ表示
  - 完了処理後の自動画面遷移

  ルーティングとナビゲーション

  - /shopping-lists（一覧画面）および/shopping-lists/:id（詳細画面）を追加
  - PrivateRoute配下での認証必須設定

  技術的配慮

  - JSON:API形式とフロントエンド型定義の整合性確保
  - lock_versionによる楽観的同時実行制御
  - エラー時の適切なユーザーフィードバック
  - パフォーマンスを考慮した効率的なデータ取得

 ### 編集ファイル

  新規作成

  - liff/src/types/shoppingList.ts
  - liff/src/api/shoppingLists.ts
  - liff/src/pages/ShoppingLists/ShoppingLists.tsx
  - liff/src/pages/ShoppingLists/ShoppingListDetail.tsx
  - liff/test/shoppingLists.test.ts

  修正

  - backend/app/controllers/api/v1/shopping_lists_controller.rb
  - backend/app/controllers/api/v1/shopping_list_items_controller.rb
  - backend/config/routes.rb
  - liff/src/App.tsx
  - backend/spec/requests/api/v1/shopping_list_items_spec.rb
  - backend/spec/models/shopping_list_spec.rb