### PR TITLE
feature/issue 119 recipes suggest api

### DIFF
--- a/backend/app/controllers/api/v1/recipes_controller.rb
+++ b/backend/app/controllers/api/v1/recipes_controller.rb
@@ -19,6 +19,59 @@ class Api::V1::RecipesController < ApplicationController
     }
   end
 
+  # POST /api/v1/recipes/suggest
+  def suggest
+    begin
+      # パラメータの取得と検証
+      suggestion_params = params.fetch(:recipe_suggestion, {})
+      ingredients = suggestion_params[:ingredients]
+      preferences = suggestion_params[:preferences] || {}
+
+      # 入力検証
+      if ingredients.present? && !ingredients.is_a?(Array)
+        return render json: {
+          success: false,
+          message: "食材は配列で指定してください",
+          errors: ["ingredients must be an array"]
+        }, status: 400
+      end
+
+      # RecipeGeneratorを使用してレシピを生成
+      generator = RecipeGenerator.new(user: current_user)
+
+      recipe = if ingredients.present?
+                 # 指定された食材からレシピ生成
+                 generator.generate_from_ingredients(ingredients, preferences)
+               else
+                 # ユーザーの在庫食材からレシピ生成
+                 generator.generate_from_user_ingredients(preferences)
+               end
+
+      Rails.logger.info "Recipe suggested successfully: #{recipe.title} (ID: #{recipe.id}) for user #{current_user.id}"
+
+      render json: {
+        success: true,
+        data: recipe_detail_json(recipe)
+      }
+
+    rescue RecipeGenerator::GenerationError => e
+      Rails.logger.warn "Recipe generation error for user #{current_user.id}: #{e.message}"
+      render json: {
+        success: false,
+        message: "レシピ生成に失敗しました",
+        errors: [e.message]
+      }, status: 422
+
+    rescue => e
+      Rails.logger.error "Unexpected error in recipe suggestion for user #{current_user.id}: #{e.message}"
+      Rails.logger.error e.backtrace.join("\n")
+      render json: {
+        success: false,
+        message: "内部エラーが発生しました。しばらくしてから再度お試しください。"
+      }, status: 500
+    end
+  end
+
   private
 
   def set_recipe

--- a/backend/app/controllers/api/v1/recipes_controller.rb
+++ b/backend/app/controllers/api/v1/recipes_controller.rb
@@ -126,8 +126,16 @@ class Api::V1::RecipesController < ApplicationController
   end
 
   def normalize_preferences(pref)
-    # テスト期待に合わせ、キー・値を文字列化（配列も各要素を文字列化）
-    pref.stringify_keys.transform_values do |v|
+    # フロントエンドのキー名をRecipeGeneratorの期待する形式に変換
+    normalized = pref.stringify_keys
+
+    # difficulty_level → difficulty にマッピング
+    if normalized.key?('difficulty_level')
+      normalized['difficulty'] = normalized.delete('difficulty_level')
+    end
+
+    # テスト期待に合わせ、値を文字列化（配列も各要素を文字列化）
+    normalized.transform_values do |v|
       if v.is_a?(Array)
         v.map { |e| e.to_s }
       else

--- a/backend/app/services/llm/openai_service.rb
+++ b/backend/app/services/llm/openai_service.rb
@@ -22,16 +22,20 @@ module Llm
       params = {
         model: model,
         messages: to_openai_messages(messages),
-        temperature: temperature,
-        max_tokens: max_tokens,
         response_format: rfmt
       }.compact
 
-      # GPT-5系モデルには推論関連パラメータを付与
+      # GPT-5系モデルの場合はmax_completion_tokensを使用し、推論関連パラメータを付与
+      # temperatureは1（デフォルト）のみサポートのため除外
       if model.start_with?("gpt-5")
+        params[:max_completion_tokens] = max_tokens
         params[:reasoning_effort] = config_value(:reasoning_effort)
         params[:verbosity] = config_value(:verbosity)
         Rails.logger.warn("[LLM] Using GPT-5 model; applying reasoning_effort/verbosity") if defined?(Rails)
+      else
+        # 従来のモデルはmax_tokensとtemperatureを使用
+        params[:max_tokens] = max_tokens
+        params[:temperature] = temperature
       end
 
       started = Process.clock_gettime(Process::CLOCK_MONOTONIC)

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -50,7 +50,11 @@ Rails.application.routes.draw do
       end
 
       # Recipes and recipe histories
-      resources :recipes, only: [ :index, :show ]
+      resources :recipes, only: [ :index, :show ] do
+        collection do
+          post :suggest
+        end
+      end
       resources :recipe_histories, only: [ :index, :show, :create, :update, :destroy ]
 
       # Shopping lists and items

--- a/backend/spec/requests/api/v1/recipes_suggest_spec.rb
+++ b/backend/spec/requests/api/v1/recipes_suggest_spec.rb
@@ -1,0 +1,161 @@
+require 'rails_helper'
+
+RSpec.describe "POST /api/v1/recipes/suggest", type: :request do
+  let(:user) { create(:user) }
+  let(:headers) { auth_headers(user) }
+
+  describe "POST /api/v1/recipes/suggest" do
+    context "認証済みユーザーの場合" do
+      context "食材を指定してレシピ提案する場合" do
+        let(:request_params) do
+          {
+            recipe_suggestion: {
+              ingredients: ["玉ねぎ", "豚肉", "人参"],
+              preferences: {
+                cooking_time: 30,
+                difficulty_level: "easy",
+                cuisine_type: "和食",
+                dietary_restrictions: ["ベジタリアン"]
+              }
+            }
+          }
+        end
+
+        it "指定食材からレシピを生成して返す" do
+          # RecipeGeneratorをモック化
+          recipe = create(:recipe, user: user, title: "豚肉と野菜の炒め物")
+          generator = instance_double(RecipeGenerator)
+          allow(RecipeGenerator).to receive(:new).with(user: user).and_return(generator)
+          allow(generator).to receive(:generate_from_ingredients)
+            .with(["玉ねぎ", "豚肉", "人参"], {
+              cooking_time: 30,
+              difficulty_level: "easy",
+              cuisine_type: "和食",
+              dietary_restrictions: ["ベジタリアン"]
+            })
+            .and_return(recipe)
+
+          post "/api/v1/recipes/suggest", params: request_params, headers: headers
+
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body["success"]).to be true
+          expect(response.parsed_body["data"]["id"]).to eq recipe.id
+          expect(response.parsed_body["data"]["title"]).to eq "豚肉と野菜の炒め物"
+        end
+      end
+
+      context "食材を指定せずにレシピ提案する場合" do
+        let(:request_params) do
+          {
+            recipe_suggestion: {
+              preferences: {
+                cooking_time: 20,
+                difficulty_level: "medium"
+              }
+            }
+          }
+        end
+
+        before do
+          # ユーザーの在庫食材を作成
+          ingredient1 = create(:ingredient, name: "鶏肉")
+          ingredient2 = create(:ingredient, name: "キャベツ")
+          create(:user_ingredient, user: user, ingredient: ingredient1, quantity: 300, unit: "g")
+          create(:user_ingredient, user: user, ingredient: ingredient2, quantity: 1, unit: "個")
+        end
+
+        it "ユーザーの在庫食材からレシピを生成して返す" do
+          recipe = create(:recipe, user: user, title: "鶏肉とキャベツの炒め物")
+          generator = instance_double(RecipeGenerator)
+          allow(RecipeGenerator).to receive(:new).with(user: user).and_return(generator)
+          allow(generator).to receive(:generate_from_user_ingredients)
+            .with({
+              cooking_time: 20,
+              difficulty_level: "medium"
+            })
+            .and_return(recipe)
+
+          post "/api/v1/recipes/suggest", params: request_params, headers: headers
+
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body["success"]).to be true
+          expect(response.parsed_body["data"]["id"]).to eq recipe.id
+          expect(response.parsed_body["data"]["title"]).to eq "鶏肉とキャベツの炒め物"
+        end
+      end
+
+      context "パラメータなしでレシピ提案する場合" do
+        it "ユーザーの在庫食材からレシピを生成して返す" do
+          recipe = create(:recipe, user: user, title: "簡単レシピ")
+          generator = instance_double(RecipeGenerator)
+          allow(RecipeGenerator).to receive(:new).with(user: user).and_return(generator)
+          allow(generator).to receive(:generate_from_user_ingredients).with({}).and_return(recipe)
+
+          post "/api/v1/recipes/suggest", headers: headers
+
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body["success"]).to be true
+          expect(response.parsed_body["data"]["id"]).to eq recipe.id
+        end
+      end
+
+      context "バリデーションエラーの場合" do
+        it "食材が配列でない場合は400エラーを返す" do
+          request_params = {
+            recipe_suggestion: {
+              ingredients: "玉ねぎ"  # 配列ではない
+            }
+          }
+
+          post "/api/v1/recipes/suggest", params: request_params, headers: headers
+
+          expect(response).to have_http_status(:bad_request)
+          expect(response.parsed_body["success"]).to be false
+          expect(response.parsed_body["message"]).to eq "食材は配列で指定してください"
+          expect(response.parsed_body["errors"]).to include("ingredients must be an array")
+        end
+      end
+
+      context "レシピ生成エラーの場合" do
+        it "RecipeGenerator::GenerationErrorが発生した場合は422エラーを返す" do
+          generator = instance_double(RecipeGenerator)
+          allow(RecipeGenerator).to receive(:new).with(user: user).and_return(generator)
+          allow(generator).to receive(:generate_from_user_ingredients)
+            .with({})
+            .and_raise(RecipeGenerator::GenerationError, "利用可能な食材が見つかりません")
+
+          post "/api/v1/recipes/suggest", headers: headers
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.parsed_body["success"]).to be false
+          expect(response.parsed_body["message"]).to eq "レシピ生成に失敗しました"
+          expect(response.parsed_body["errors"]).to include("利用可能な食材が見つかりません")
+        end
+      end
+
+      context "想定外のエラーの場合" do
+        it "500エラーを返す" do
+          generator = instance_double(RecipeGenerator)
+          allow(RecipeGenerator).to receive(:new).with(user: user).and_return(generator)
+          allow(generator).to receive(:generate_from_user_ingredients)
+            .with({})
+            .and_raise(StandardError, "予期しないエラー")
+
+          post "/api/v1/recipes/suggest", headers: headers
+
+          expect(response).to have_http_status(:internal_server_error)
+          expect(response.parsed_body["success"]).to be false
+          expect(response.parsed_body["message"]).to eq "内部エラーが発生しました。しばらくしてから再度お試しください。"
+        end
+      end
+    end
+
+    context "未認証ユーザーの場合" do
+      it "401エラーを返す" do
+        post "/api/v1/recipes/suggest"
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/recipes_suggest_spec.rb
+++ b/backend/spec/requests/api/v1/recipes_suggest_spec.rb
@@ -41,8 +41,6 @@ RSpec.describe "POST /api/v1/recipes/suggest", type: :request do
 
           post "/api/v1/recipes/suggest", params: request_params, headers: auth_header_for(user)
 
-          puts "Response status: #{response.status}"
-          puts "Response body: #{response.body}" if response.status != 200
           expect(response).to have_http_status(:ok)
           expect(response.parsed_body["success"]).to be true
           expect(response.parsed_body["data"]["id"]).to eq recipe.id
@@ -115,8 +113,6 @@ RSpec.describe "POST /api/v1/recipes/suggest", type: :request do
 
           post "/api/v1/recipes/suggest", params: request_params, headers: auth_header_for(user)
 
-          puts "Response status: #{response.status}"
-          puts "Response body: #{response.body}"
           expect(response).to have_http_status(:unprocessable_entity)
           expect(response.parsed_body["success"]).to be false
           expect(response.parsed_body["message"]).to eq "食材は配列で指定してください"

--- a/frontend/src/components/recipes/RecipeDetailView.tsx
+++ b/frontend/src/components/recipes/RecipeDetailView.tsx
@@ -1,0 +1,140 @@
+import React, { useState } from 'react'
+import type { Recipe, IngredientCheckState } from '../../types/recipe'
+import { FaClock, FaUtensils, FaCheck } from 'react-icons/fa'
+
+interface RecipeDetailViewProps {
+  recipe: Recipe
+  onSaveToHistory?: () => void
+  showSaveButton?: boolean
+}
+
+const RecipeDetailView: React.FC<RecipeDetailViewProps> = ({
+  recipe,
+  onSaveToHistory,
+  showSaveButton = true
+}) => {
+  const [checkedIngredients, setCheckedIngredients] = useState<IngredientCheckState>({})
+
+  const handleIngredientCheck = (ingredientId: number) => {
+    setCheckedIngredients(prev => ({
+      ...prev,
+      [ingredientId]: !prev[ingredientId]
+    }))
+  }
+
+  const getDifficultyColor = (difficulty: string) => {
+    switch (difficulty.toLowerCase()) {
+      case 'easy':
+      case 'かんたん':
+        return 'text-green-600 bg-green-100'
+      case 'medium':
+      case 'ふつう':
+        return 'text-yellow-600 bg-yellow-100'
+      case 'hard':
+      case 'むずかしい':
+        return 'text-red-600 bg-red-100'
+      default:
+        return 'text-gray-600 bg-gray-100'
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* レシピヘッダー */}
+      <div className="text-center border-b pb-4">
+        <h2 className="text-2xl font-bold text-gray-900 mb-2">{recipe.title}</h2>
+        <div className="flex justify-center items-center space-x-4 text-sm text-gray-600">
+          <div className="flex items-center">
+            <FaClock className="mr-1" />
+            <span>{recipe.formatted_cooking_time}</span>
+          </div>
+          <div className="flex items-center">
+            <FaUtensils className="mr-1" />
+            <span>{recipe.servings}人分</span>
+          </div>
+          <span className={`px-2 py-1 rounded-full text-xs font-medium ${getDifficultyColor(recipe.difficulty_display)}`}>
+            {recipe.difficulty_display}
+          </span>
+        </div>
+      </div>
+
+      {/* 材料リスト */}
+      {recipe.ingredients && recipe.ingredients.length > 0 && (
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900 mb-3">材料</h3>
+          <div className="bg-gray-50 rounded-lg p-4">
+            <div className="space-y-2">
+              {recipe.ingredients.map((ingredient) => (
+                <label
+                  key={ingredient.id}
+                  className="flex items-center space-x-3 cursor-pointer hover:bg-gray-100 p-2 rounded"
+                >
+                  <input
+                    type="checkbox"
+                    checked={checkedIngredients[ingredient.id] || false}
+                    onChange={() => handleIngredientCheck(ingredient.id)}
+                    className="h-4 w-4 text-pink-600 focus:ring-pink-500 border-gray-300 rounded"
+                  />
+                  <div className="flex-1 flex justify-between items-center">
+                    <span className={`text-sm ${checkedIngredients[ingredient.id] ? 'line-through text-gray-500' : 'text-gray-900'}`}>
+                      {ingredient.name}
+                      {ingredient.is_optional && (
+                        <span className="text-xs text-gray-500 ml-1">(お好みで)</span>
+                      )}
+                    </span>
+                    <span className={`text-sm font-medium ${checkedIngredients[ingredient.id] ? 'line-through text-gray-500' : 'text-gray-600'}`}>
+                      {ingredient.amount && ingredient.unit
+                        ? `${ingredient.amount}${ingredient.unit}`
+                        : ingredient.amount
+                        ? ingredient.amount
+                        : ingredient.unit || '適量'
+                      }
+                    </span>
+                  </div>
+                  {checkedIngredients[ingredient.id] && (
+                    <FaCheck className="text-green-500" />
+                  )}
+                </label>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 調理手順 */}
+      {recipe.steps && recipe.steps.length > 0 && (
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900 mb-3">調理手順</h3>
+          <div className="space-y-3">
+            {recipe.steps.map((step, index) => (
+              <div key={index} className="flex items-start space-x-3">
+                <div className="flex-shrink-0 w-6 h-6 bg-pink-500 text-white rounded-full flex items-center justify-center text-sm font-medium">
+                  {index + 1}
+                </div>
+                <p className="text-gray-700 leading-relaxed">{step}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* 保存ボタン */}
+      {showSaveButton && onSaveToHistory && (
+        <div className="pt-4 border-t">
+          <button
+            onClick={onSaveToHistory}
+            className="w-full bg-pink-500 text-white py-2 px-4 rounded-md hover:bg-pink-600 transition-colors font-medium flex items-center justify-center"
+          >
+            <FaCheck className="mr-2" />
+            調理履歴に保存
+          </button>
+          <p className="text-xs text-gray-500 text-center mt-2">
+            このレシピを作った記録として保存できます
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default RecipeDetailView

--- a/frontend/src/components/recipes/RecipeSuggestModal.tsx
+++ b/frontend/src/components/recipes/RecipeSuggestModal.tsx
@@ -238,9 +238,20 @@ const RecipeSuggestModal: React.FC<RecipeSuggestModalProps> = ({
       {generatedRecipe && (
         <RecipeDetailView
           recipe={generatedRecipe}
-          onSaveToHistory={() => {
-            // TODO: レシピ履歴保存機能の実装
-            console.log('レシピ履歴に保存')
+          onSaveToHistory={async () => {
+            if (!generatedRecipe) return
+            try {
+              await recipesApi.createRecipeHistory({
+                recipe_id: generatedRecipe.id,
+                memo: `${generatedRecipe.title}を作りました`,
+                cooked_at: new Date().toISOString()
+              })
+              // 成功時は親コンポーネントに通知
+              onRecipeGenerated?.(generatedRecipe)
+            } catch (error) {
+              console.error('調理履歴保存エラー:', error)
+              setError('調理履歴の保存に失敗しました')
+            }
           }}
         />
       )}

--- a/frontend/src/components/recipes/RecipeSuggestModal.tsx
+++ b/frontend/src/components/recipes/RecipeSuggestModal.tsx
@@ -1,0 +1,278 @@
+import React, { useState } from 'react'
+import Modal from '../ui/Modal'
+import type { Recipe } from '../../types/recipe'
+import { recipesApi, type RecipeSuggestionRequest } from '../../api/recipes'
+import RecipeDetailView from './RecipeDetailView'
+
+interface RecipeSuggestModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onRecipeGenerated?: (recipe: Recipe) => void
+}
+
+const RecipeSuggestModal: React.FC<RecipeSuggestModalProps> = ({
+  isOpen,
+  onClose,
+  onRecipeGenerated
+}) => {
+  const [currentStep, setCurrentStep] = useState<'preferences' | 'result'>('preferences')
+  const [isGenerating, setIsGenerating] = useState(false)
+  const [generatedRecipe, setGeneratedRecipe] = useState<Recipe | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  // フォーム状態
+  const [ingredients, setIngredients] = useState<string>('')
+  const [preferences, setPreferences] = useState<RecipeSuggestionRequest['preferences']>({
+    cooking_time: undefined,
+    difficulty_level: undefined,
+    cuisine_type: '',
+    dietary_restrictions: []
+  })
+
+  const resetModal = () => {
+    setCurrentStep('preferences')
+    setGeneratedRecipe(null)
+    setError(null)
+    setIngredients('')
+    setPreferences({
+      cooking_time: undefined,
+      difficulty_level: undefined,
+      cuisine_type: '',
+      dietary_restrictions: []
+    })
+  }
+
+  const handleClose = () => {
+    resetModal()
+    onClose()
+  }
+
+  const handleGenerate = async () => {
+    setIsGenerating(true)
+    setError(null)
+
+    try {
+      // バリデーション
+      if (preferences?.cooking_time && (preferences.cooking_time < 1 || preferences.cooking_time > 300)) {
+        setError('調理時間は1分〜300分の間で入力してください')
+        return
+      }
+
+      const requestParams: RecipeSuggestionRequest = {
+        ...(ingredients.trim() && {
+          ingredients: ingredients.split(',').map(item => item.trim()).filter(Boolean)
+        }),
+        preferences: {
+          ...(preferences?.cooking_time && { cooking_time: preferences.cooking_time }),
+          ...(preferences?.difficulty_level && { difficulty_level: preferences.difficulty_level }),
+          ...(preferences?.cuisine_type?.trim() && { cuisine_type: preferences.cuisine_type.trim() }),
+          ...(preferences?.dietary_restrictions?.length && { dietary_restrictions: preferences.dietary_restrictions })
+        }
+      }
+
+      const recipe = await recipesApi.suggestRecipe(requestParams)
+      setGeneratedRecipe(recipe)
+      setCurrentStep('result')
+      onRecipeGenerated?.(recipe)
+    } catch (err) {
+      let errorMessage = 'レシピ生成に失敗しました'
+
+      if (err instanceof Error) {
+        if (err.message.includes('401')) {
+          errorMessage = 'ログインが必要です。再度ログインしてください。'
+        } else if (err.message.includes('422')) {
+          errorMessage = err.message || '入力内容に問題があります。設定を確認してください。'
+        } else if (err.message.includes('500')) {
+          errorMessage = 'サーバーエラーが発生しました。しばらくしてから再度お試しください。'
+        } else if (err.message.includes('Network')) {
+          errorMessage = 'ネットワークエラーが発生しました。通信環境を確認してください。'
+        } else {
+          errorMessage = err.message
+        }
+      }
+
+      setError(errorMessage)
+    } finally {
+      setIsGenerating(false)
+    }
+  }
+
+  const handleDietaryRestrictionChange = (restriction: string, checked: boolean) => {
+    setPreferences((prev: RecipeSuggestionRequest['preferences']) => ({
+      ...prev,
+      dietary_restrictions: checked
+        ? [...(prev?.dietary_restrictions || []), restriction]
+        : (prev?.dietary_restrictions || []).filter((item: string) => item !== restriction)
+    }))
+  }
+
+  const renderPreferencesForm = () => (
+    <div className="space-y-6">
+      {/* 食材指定 */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          使いたい食材（任意）
+        </label>
+        <textarea
+          value={ingredients}
+          onChange={(e) => setIngredients(e.target.value)}
+          placeholder="例: 玉ねぎ, 豚肉, 人参（カンマ区切りで入力）"
+          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-500"
+          rows={2}
+        />
+        <p className="text-xs text-gray-500 mt-1">
+          空欄の場合、在庫食材から自動で選択されます
+        </p>
+      </div>
+
+      {/* 調理時間 */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          調理時間（分）
+        </label>
+        <input
+          type="number"
+          value={preferences?.cooking_time || ''}
+          onChange={(e) => setPreferences((prev: RecipeSuggestionRequest['preferences']) => ({
+            ...prev,
+            cooking_time: e.target.value ? parseInt(e.target.value) : undefined
+          }))}
+          placeholder="例: 30"
+          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-500"
+          min="1"
+          max="300"
+        />
+      </div>
+
+      {/* 難易度 */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          難易度
+        </label>
+        <select
+          value={preferences?.difficulty_level || ''}
+          onChange={(e) => setPreferences((prev: RecipeSuggestionRequest['preferences']) => ({
+            ...prev,
+            difficulty_level: e.target.value as 'easy' | 'medium' | 'hard' | undefined
+          }))}
+          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-500"
+        >
+          <option value="">選択してください</option>
+          <option value="easy">かんたん</option>
+          <option value="medium">ふつう</option>
+          <option value="hard">むずかしい</option>
+        </select>
+      </div>
+
+      {/* 料理ジャンル */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          料理ジャンル
+        </label>
+        <input
+          type="text"
+          value={preferences?.cuisine_type || ''}
+          onChange={(e) => setPreferences((prev: RecipeSuggestionRequest['preferences']) => ({
+            ...prev,
+            cuisine_type: e.target.value
+          }))}
+          placeholder="例: 和食, 中華, イタリアン"
+          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-500"
+        />
+      </div>
+
+      {/* 食事制限 */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          食事制限
+        </label>
+        <div className="space-y-2">
+          {['ベジタリアン', 'ヴィーガン', '糖質制限', '塩分制限', 'グルテンフリー'].map(restriction => (
+            <label key={restriction} className="flex items-center">
+              <input
+                type="checkbox"
+                checked={preferences?.dietary_restrictions?.includes(restriction) || false}
+                onChange={(e) => handleDietaryRestrictionChange(restriction, e.target.checked)}
+                className="mr-2 h-4 w-4 text-pink-600 focus:ring-pink-500 border-gray-300 rounded"
+              />
+              <span className="text-sm text-gray-700">{restriction}</span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-md p-3">
+          <p className="text-red-600 text-sm">{error}</p>
+        </div>
+      )}
+
+      <div className="flex justify-end space-x-3">
+        <button
+          onClick={handleClose}
+          className="px-4 py-2 text-gray-600 border border-gray-300 rounded-md hover:bg-gray-50"
+          disabled={isGenerating}
+        >
+          キャンセル
+        </button>
+        <button
+          onClick={handleGenerate}
+          className="px-4 py-2 bg-pink-500 text-white rounded-md hover:bg-pink-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center"
+          disabled={isGenerating}
+        >
+          {isGenerating ? (
+            <>
+              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
+              レシピ生成中...
+            </>
+          ) : (
+            'レシピを生成'
+          )}
+        </button>
+      </div>
+    </div>
+  )
+
+  const renderResult = () => (
+    <div>
+      {generatedRecipe && (
+        <RecipeDetailView
+          recipe={generatedRecipe}
+          onSaveToHistory={() => {
+            // TODO: レシピ履歴保存機能の実装
+            console.log('レシピ履歴に保存')
+          }}
+        />
+      )}
+      <div className="flex justify-end space-x-3 mt-6 pt-4 border-t">
+        <button
+          onClick={() => setCurrentStep('preferences')}
+          className="px-4 py-2 text-gray-600 border border-gray-300 rounded-md hover:bg-gray-50"
+        >
+          再生成
+        </button>
+        <button
+          onClick={handleClose}
+          className="px-4 py-2 bg-pink-500 text-white rounded-md hover:bg-pink-600"
+        >
+          閉じる
+        </button>
+      </div>
+    </div>
+  )
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      title={currentStep === 'preferences' ? 'レシピ提案設定' : '生成されたレシピ'}
+      size={currentStep === 'result' ? 'lg' : 'md'}
+    >
+      <div className={`${currentStep === 'result' ? 'max-h-[80vh]' : 'max-h-96'} overflow-y-auto`}>
+        {currentStep === 'preferences' ? renderPreferencesForm() : renderResult()}
+      </div>
+    </Modal>
+  )
+}
+
+export default RecipeSuggestModal

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -5,9 +5,10 @@ type ModalProps = {
   title?: string
   onClose: () => void
   children: React.ReactNode
+  size?: 'sm' | 'md' | 'lg' | 'xl'
 }
 
-const Modal: React.FC<ModalProps> = ({ isOpen, title, onClose, children }) => {
+const Modal: React.FC<ModalProps> = ({ isOpen, title, onClose, children, size = 'md' }) => {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose()
@@ -20,10 +21,25 @@ const Modal: React.FC<ModalProps> = ({ isOpen, title, onClose, children }) => {
 
   if (!isOpen) return null
 
+  const getSizeClass = () => {
+    switch (size) {
+      case 'sm':
+        return 'max-w-md'
+      case 'md':
+        return 'max-w-lg'
+      case 'lg':
+        return 'max-w-2xl'
+      case 'xl':
+        return 'max-w-4xl'
+      default:
+        return 'max-w-lg'
+    }
+  }
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div className="absolute inset-0 bg-black/40" onClick={onClose} />
-      <div className="relative bg-white rounded-lg shadow-lg w-full max-w-lg mx-4">
+      <div className={`relative bg-white rounded-lg shadow-lg w-full ${getSizeClass()} mx-4`}>
         <div className="border-b px-4 py-3 flex justify-between items-center">
           <h3 className="text-lg font-semibold">{title}</h3>
           <button onClick={onClose} aria-label="close" className="text-gray-500 hover:text-gray-700">×</button>

--- a/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -4,12 +4,23 @@ import { useAuth } from '../../hooks/useAuth';
 import { imageRecognitionApi } from '../../api/imageRecognition';
 import { FaCamera, FaClipboardList, FaHistory, FaCog } from 'react-icons/fa';
 import { HiSparkles } from 'react-icons/hi';
+import RecipeSuggestModal from '../../components/recipes/RecipeSuggestModal';
+import Toast from '../../components/Toast';
+import type { Recipe } from '../../types/recipe';
 
 const Dashboard: React.FC = () => {
   const { user } = useAuth();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [isUploading, setIsUploading] = useState(false);
   const [uploadMessage, setUploadMessage] = useState<string | null>(null);
+
+  // レシピ提案モーダル関連の状態
+  const [isRecipeModalOpen, setIsRecipeModalOpen] = useState(false);
+
+  // トースト通知関連の状態
+  const [toastMessage, setToastMessage] = useState<string>('');
+  const [toastType, setToastType] = useState<'success' | 'error' | 'info'>('info');
+  const [isToastVisible, setIsToastVisible] = useState(false);
 
   const today = new Date();
   const formattedDate = `${today.getFullYear()}年${today.getMonth() + 1}月${today.getDate()}日 (${['日', '月', '火', '水', '木', '金', '土'][today.getDay()]})`;
@@ -54,9 +65,22 @@ const Dashboard: React.FC = () => {
     }
   };
 
+  const showToast = (message: string, type: 'success' | 'error' | 'info' = 'info') => {
+    setToastMessage(message);
+    setToastType(type);
+    setIsToastVisible(true);
+  };
+
   const handleRecipeSuggest = () => {
-    // TODO: レシピ提案機能の実装
-    console.log('レシピ提案機能');
+    setIsRecipeModalOpen(true);
+  };
+
+  const handleRecipeGenerated = (recipe: Recipe) => {
+    showToast(`「${recipe.title}」のレシピを生成しました！`, 'success');
+  };
+
+  const handleModalClose = () => {
+    setIsRecipeModalOpen(false);
   };
 
   return (
@@ -167,6 +191,21 @@ const Dashboard: React.FC = () => {
             </div>
           </Link>
         </div>
+
+        {/* レシピ提案モーダル */}
+        <RecipeSuggestModal
+          isOpen={isRecipeModalOpen}
+          onClose={handleModalClose}
+          onRecipeGenerated={handleRecipeGenerated}
+        />
+
+        {/* トースト通知 */}
+        <Toast
+          message={toastMessage}
+          type={toastType}
+          isVisible={isToastVisible}
+          onClose={() => setIsToastVisible(false)}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## 概要

  Issue #119 Web版 AIレシピ提案API実装の実装。
  フロントエンドのrecipesApi.suggestRecipe()に対応するバックエンドAPIエンドポイントの実装と、フロントエンド完全統合、OpenAI API GPT-5対応を行いました。

  ### 実装内容

  #### バックエンドAPI実装
  - POST /api/v1/recipes/suggest エンドポイント追加
  - JWT認証必須、Strong Parametersによる入力検証
  - RecipeGeneratorサービスとの連携
  - 食材指定あり/なし両方のレシピ生成に対応
  - 包括的なエラーハンドリング（401/422/500）

  #### フロントエンド統合
  - RecipeSuggestModalコンポーネント実装
  - プリファレンス設定フォーム（食材、調理時間、難易度、料理ジャンル、食事制限）
  - RecipeDetailViewによる生成結果表示
  - 調理履歴保存機能実装

  #### OpenAI API GPT-5対応
  - max_tokens → max_completion_tokens パラメータ変更
  - temperature制限（デフォルト値1のみ）への対応
  - reasoning_effort、verbosity パラメータ追加

  #### パラメータマッピング
  - フロントエンド difficulty_level → バックエンド difficulty 変換処理
  - 文字列正規化処理追加

  #### テスト実装
  - RSpecリクエストテスト7件（正常系3件、異常系4件）
  - 認証、バリデーション、エラーケースの包括的テスト

  ### 編集ファイル

  #### 新規作成
  - backend/spec/requests/api/v1/recipes_suggest_spec.rb

  #### 変更ファイル
  - backend/config/routes.rb（suggestルート追加）
  - backend/app/controllers/api/v1/recipes_controller.rb（suggestアクション追加）
  - backend/app/services/llm/openai_service.rb（GPT-5パラメータ対応）
  - frontend/src/components/recipes/RecipeSuggestModal.tsx（完全実装）
  - frontend/src/pages/Dashboard/Dashboard.tsx（モーダル統合）
