### PR TITLE
feature/issue 52 favorite recipe model

### DIFF
--- a/backend/app/controllers/api/v1/favorite_recipes_controller.rb
+++ b/backend/app/controllers/api/v1/favorite_recipes_controller.rb
@@ -1,0 +1,90 @@
+class Api::V1::FavoriteRecipesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :find_favorite_recipe, only: [ :destroy ]
+
+  # GET /api/v1/favorite_recipes
+  # お気に入りレシピ一覧を取得
+  def index
+    favorites = current_user.favorite_recipes
+                  .includes(:recipe)
+                  .recent
+
+    # Kaminari ページネーション（デフォルト20、最大100）
+    per = [ [ (params[:per_page] || 20).to_i, 1 ].max, 100 ].min
+    favorites = favorites.page(params[:page]).per(per)
+
+    render json: {
+      success: true,
+      data: favorites.map { |favorite| favorite_recipe_json(favorite) },
+      meta: {
+        current_page: favorites.current_page,
+        per_page: favorites.limit_value,
+        total_pages: favorites.total_pages,
+        total_count: favorites.total_count
+      }
+    }
+  end
+
+  # POST /api/v1/favorite_recipes
+  # お気に入りレシピを追加
+  def create
+    favorite = current_user.favorite_recipes.build(favorite_recipe_params)
+
+    if favorite.save
+      render json: {
+        success: true,
+        data: favorite_recipe_json(favorite),
+        message: "お気に入りに追加しました"
+      }, status: :created
+    else
+      render json: {
+        success: false,
+        errors: favorite.errors.full_messages,
+        message: "お気に入りの追加に失敗しました"
+      }, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /api/v1/favorite_recipes/:id
+  # お気に入りレシピを削除
+  def destroy
+    @favorite_recipe.destroy!
+
+    render json: {
+      success: true,
+      message: "お気に入りから削除しました"
+    }
+  rescue ActiveRecord::RecordNotDestroyed => e
+    render json: {
+      success: false,
+      errors: e.record.errors.full_messages,
+      message: "お気に入りの削除に失敗しました"
+    }, status: :unprocessable_entity
+  end
+
+  private
+
+  def find_favorite_recipe
+    @favorite_recipe = current_user.favorite_recipes.find(params[:id])
+  end
+
+  def favorite_recipe_params
+    params.require(:favorite_recipe).permit(:recipe_id)
+  end
+
+  def favorite_recipe_json(favorite)
+    {
+      id: favorite.id,
+      user_id: favorite.user_id,
+      recipe_id: favorite.recipe_id,
+      created_at: favorite.created_at,
+      recipe: favorite.recipe ? {
+        id: favorite.recipe.id,
+        title: favorite.recipe.title,
+        cooking_time: favorite.recipe.cooking_time,
+        difficulty: favorite.recipe.difficulty,
+        servings: favorite.recipe.servings
+      } : nil
+    }
+  end
+end

--- a/backend/app/controllers/api/v1/favorite_recipes_controller.rb
+++ b/backend/app/controllers/api/v1/favorite_recipes_controller.rb
@@ -39,7 +39,7 @@ class Api::V1::FavoriteRecipesController < ApplicationController
     else
       render json: {
         success: false,
-        errors: favorite.errors.full_messages,
+        errors: favorite.errors.messages.transform_keys { |key| key == :recipe ? :recipe_id : key }.values.flatten,
         message: "お気に入りの追加に失敗しました"
       }, status: :unprocessable_entity
     end

--- a/backend/app/models/favorite_recipe.rb
+++ b/backend/app/models/favorite_recipe.rb
@@ -1,0 +1,15 @@
+class FavoriteRecipe < ApplicationRecord
+  # Associations
+  belongs_to :user
+  belongs_to :recipe
+
+  # Validations
+  validates :user_id, presence: true
+  validates :recipe_id, presence: true
+  validates :recipe_id, uniqueness: { scope: :user_id, message: "は既にお気に入りに追加されています" }
+
+  # Scopes
+  scope :recent, -> { order(created_at: :desc) }
+  scope :by_user, ->(user_id) { where(user_id: user_id) }
+  scope :by_recipe, ->(recipe_id) { where(recipe_id: recipe_id) }
+end

--- a/backend/app/models/favorite_recipe.rb
+++ b/backend/app/models/favorite_recipe.rb
@@ -6,7 +6,7 @@ class FavoriteRecipe < ApplicationRecord
   # Validations
   validates :user_id, presence: true
   validates :recipe_id, presence: true
-  validates :recipe_id, uniqueness: { scope: :user_id, message: "は既にお気に入りに追加されています" }
+  validates :recipe_id, uniqueness: { scope: :user_id, message: "レシピIDは既にお気に入りに追加されています" }
 
   # Scopes
   scope :recent, -> { order(created_at: :desc) }

--- a/backend/app/models/recipe.rb
+++ b/backend/app/models/recipe.rb
@@ -12,6 +12,8 @@ class Recipe < ApplicationRecord
   has_many :ingredients, through: :recipe_ingredients
   has_many :recipe_histories, dependent: :destroy
   has_many :shopping_lists
+  has_many :favorite_recipes, dependent: :destroy
+  has_many :favorited_by_users, through: :favorite_recipes, source: :user
 
   # Validations
   validates :title, presence: true, length: { maximum: 100 }

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -20,6 +20,8 @@ class User < ApplicationRecord
   has_many :recipes, dependent: :destroy
   has_many :recipe_histories, dependent: :destroy
   has_many :shopping_lists, dependent: :destroy
+  has_many :favorite_recipes, dependent: :destroy
+  has_many :favorited_recipes, through: :favorite_recipes, source: :recipe
 
   # Validations
   validates :name, presence: true, length: { maximum: 50 }

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
           post :suggest
         end
       end
+      resources :favorite_recipes, only: [ :index, :create, :destroy ]
       resources :recipe_histories, only: [ :index, :show, :create, :update, :destroy ]
 
       # Shopping lists and items

--- a/backend/db/migrate/20251003014326_create_favorite_recipes.rb
+++ b/backend/db/migrate/20251003014326_create_favorite_recipes.rb
@@ -1,0 +1,18 @@
+class CreateFavoriteRecipes < ActiveRecord::Migration[7.2]
+  def change
+    create_table :favorite_recipes do |t|
+      t.bigint :user_id, null: false, comment: "ユーザーID"
+      t.bigint :recipe_id, null: false, comment: "レシピID"
+
+      t.timestamps
+    end
+
+    add_index :favorite_recipes, :user_id
+    add_index :favorite_recipes, :recipe_id
+    add_index :favorite_recipes, [ :user_id, :created_at ], name: "index_favorite_recipes_on_user_id_and_created_at"
+    add_index :favorite_recipes, [ :user_id, :recipe_id ], unique: true, name: "index_favorite_recipes_on_user_and_recipe"
+
+    add_foreign_key :favorite_recipes, :users, on_delete: :cascade
+    add_foreign_key :favorite_recipes, :recipes, on_delete: :cascade
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,9 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_24_020624) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_03_014326) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "favorite_recipes", force: :cascade do |t|
+    t.bigint "user_id", null: false, comment: "ユーザーID"
+    t.bigint "recipe_id", null: false, comment: "レシピID"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["recipe_id"], name: "index_favorite_recipes_on_recipe_id"
+    t.index ["user_id", "created_at"], name: "index_favorite_recipes_on_user_id_and_created_at"
+    t.index ["user_id", "recipe_id"], name: "index_favorite_recipes_on_user_and_recipe", unique: true
+    t.index ["user_id"], name: "index_favorite_recipes_on_user_id"
+  end
 
   create_table "fridge_images", force: :cascade do |t|
     t.bigint "user_id", comment: "撮影したユーザー"
@@ -179,6 +190,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_24_020624) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "favorite_recipes", "recipes", on_delete: :cascade
+  add_foreign_key "favorite_recipes", "users", on_delete: :cascade
   add_foreign_key "fridge_images", "line_accounts"
   add_foreign_key "fridge_images", "users"
   add_foreign_key "line_accounts", "users", on_delete: :nullify

--- a/backend/spec/factories/favorite_recipes.rb
+++ b/backend/spec/factories/favorite_recipes.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :favorite_recipe do
     association :user, :confirmed
-    association :recipe
+    recipe { association :recipe, user: user }
   end
 end
 

--- a/backend/spec/factories/favorite_recipes.rb
+++ b/backend/spec/factories/favorite_recipes.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :favorite_recipe do
+    association :user, :confirmed
+    association :recipe
+  end
+end
+

--- a/backend/spec/models/favorite_recipe_spec.rb
+++ b/backend/spec/models/favorite_recipe_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe FavoriteRecipe, type: :model do
+  subject(:favorite_recipe) { build(:favorite_recipe) }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:recipe) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:user_id) }
+    it { is_expected.to validate_presence_of(:recipe_id) }
+
+    it "同一ユーザーが同じレシピを重複登録できない" do
+      existing = create(:favorite_recipe, user: favorite_recipe.user, recipe: favorite_recipe.recipe)
+      duplicate = build(:favorite_recipe, user: existing.user, recipe: existing.recipe)
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:recipe_id]).to include("は既にお気に入りに追加されています")
+    end
+  end
+
+  describe "scopes" do
+    let!(:older) { create(:favorite_recipe, created_at: 2.days.ago) }
+    let!(:newer) { create(:favorite_recipe, created_at: 1.day.ago) }
+
+    it "recent は新しい順に並べる" do
+      expect(described_class.recent).to eq([ newer, older ])
+    end
+
+    it "by_user は指定ユーザーのレコードのみ返す" do
+      expect(described_class.by_user(older.user_id)).to include(older)
+      expect(described_class.by_user(older.user_id)).not_to include(newer) if newer.user_id != older.user_id
+    end
+
+    it "by_recipe は指定レシピのレコードのみ返す" do
+      expect(described_class.by_recipe(older.recipe_id)).to include(older)
+      expect(described_class.by_recipe(older.recipe_id)).not_to include(newer) if newer.recipe_id != older.recipe_id
+    end
+  end
+end
+

--- a/backend/spec/models/favorite_recipe_spec.rb
+++ b/backend/spec/models/favorite_recipe_spec.rb
@@ -13,11 +13,14 @@ RSpec.describe FavoriteRecipe, type: :model do
     it { is_expected.to validate_presence_of(:recipe_id) }
 
     it "同一ユーザーが同じレシピを重複登録できない" do
-      existing = create(:favorite_recipe, user: favorite_recipe.user, recipe: favorite_recipe.recipe)
-      duplicate = build(:favorite_recipe, user: existing.user, recipe: existing.recipe)
+      user = create(:user, :confirmed)
+      recipe = create(:recipe, user: user)
+
+      create(:favorite_recipe, user: user, recipe: recipe)
+      duplicate = build(:favorite_recipe, user: user, recipe: recipe)
 
       expect(duplicate).not_to be_valid
-      expect(duplicate.errors[:recipe_id]).to include("は既にお気に入りに追加されています")
+      expect(duplicate.errors[:recipe_id]).to include("レシピIDは既にお気に入りに追加されています")
     end
   end
 

--- a/backend/spec/requests/api/v1/favorite_recipes_spec.rb
+++ b/backend/spec/requests/api/v1/favorite_recipes_spec.rb
@@ -1,0 +1,105 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::FavoriteRecipes", type: :request do
+  let(:user) { create(:user, :confirmed) }
+  let(:headers) { auth_header_for(user) }
+
+  def auth_header_for(user)
+    post "/api/v1/auth/login", params: { user: { email: user.email, password: "password123" } }, as: :json
+    { "Authorization" => response.headers["Authorization"] }
+  end
+
+  describe "GET /api/v1/favorite_recipes" do
+    before do
+      create_list(:favorite_recipe, 3, user: user)
+      create(:favorite_recipe) # 他ユーザー分
+    end
+
+    it "認証なしは401" do
+      get "/api/v1/favorite_recipes", as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "自ユーザーのお気に入りのみ返す" do
+      get "/api/v1/favorite_recipes", headers: headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+
+      expect(body["success"]).to eq(true)
+      expect(body["data"].size).to eq(3)
+      body["data"].each do |favorite|
+        expect(favorite["user_id"]).to eq(user.id)
+        expect(favorite["recipe"]).to include("id", "title", "cooking_time", "difficulty", "servings")
+      end
+      expect(body["meta"]).to include("current_page", "per_page", "total_pages", "total_count")
+    end
+  end
+
+  describe "POST /api/v1/favorite_recipes" do
+    let(:recipe) { create(:recipe, user: user) }
+
+    it "認証なしは401" do
+      post "/api/v1/favorite_recipes", params: { favorite_recipe: { recipe_id: recipe.id } }, as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "お気に入りに追加できる" do
+      post "/api/v1/favorite_recipes", params: { favorite_recipe: { recipe_id: recipe.id } }, headers: headers, as: :json
+
+      expect(response).to have_http_status(:created)
+      body = JSON.parse(response.body)
+      expect(body["success"]).to eq(true)
+      expect(body["message"]).to eq("お気に入りに追加しました")
+      expect(body["data"]["recipe_id"]).to eq(recipe.id)
+    end
+
+    it "重複登録は422" do
+      create(:favorite_recipe, user: user, recipe: recipe)
+
+      post "/api/v1/favorite_recipes", params: { favorite_recipe: { recipe_id: recipe.id } }, headers: headers, as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      body = JSON.parse(response.body)
+      expect(body["success"]).to eq(false)
+      expect(body["errors"]).to include("レシピIDは既にお気に入りに追加されています")
+    end
+
+    it "パラメータ不足は400" do
+      expect {
+        post "/api/v1/favorite_recipes", params: {}, headers: headers, as: :json
+      }.to raise_error(ActionController::ParameterMissing)
+    end
+  end
+
+  describe "DELETE /api/v1/favorite_recipes/:id" do
+    let!(:favorite_recipe) { create(:favorite_recipe, user: user) }
+
+    it "認証なしは401" do
+      delete "/api/v1/favorite_recipes/#{favorite_recipe.id}", as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "お気に入りを削除できる" do
+      expect {
+        delete "/api/v1/favorite_recipes/#{favorite_recipe.id}", headers: headers, as: :json
+      }.to change(FavoriteRecipe, :count).by(-1)
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["success"]).to eq(true)
+      expect(body["message"]).to eq("お気に入りから削除しました")
+    end
+
+    it "他ユーザーのレコードは404" do
+      other_favorite = create(:favorite_recipe)
+
+      expect {
+        delete "/api/v1/favorite_recipes/#{other_favorite.id}", headers: headers, as: :json
+      }.not_to change(FavoriteRecipe, :count)
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end
+

--- a/backend/spec/requests/api/v1/favorite_recipes_spec.rb
+++ b/backend/spec/requests/api/v1/favorite_recipes_spec.rb
@@ -66,9 +66,11 @@ RSpec.describe "Api::V1::FavoriteRecipes", type: :request do
     end
 
     it "パラメータ不足は400" do
-      expect {
-        post "/api/v1/favorite_recipes", params: {}, headers: headers, as: :json
-      }.to raise_error(ActionController::ParameterMissing)
+      post "/api/v1/favorite_recipes", params: {}, headers: headers, as: :json
+
+      expect(response).to have_http_status(:bad_request)
+      body = JSON.parse(response.body)
+      expect(body["error"]).to include("param is missing")
     end
   end
 


### PR DESCRIPTION
## 概要
  Issue #52 FavoriteRecipeモデルとお気に入りAPIの実装

  ### 実装内容

  #### データベース設計
  - `favorite_recipes`テーブルを作成
    - `user_id`、`recipe_id`の外部キー制約
    - `[user_id, recipe_id]`のユニーク制約で重複登録を防止
    - レシピ削除時は関連するお気に入りも自動削除（`on_delete: :cascade`）

  #### モデル実装
  - `FavoriteRecipe`モデルを作成
    - User、Recipeとのアソシエーション
    - ユニークバリデーション（同一ユーザーが同じレシピを重複登録不可）
    - スコープ（`recent`、`by_user`、`by_recipe`）
  - `User`モデルに`favorite_recipes`、`favorited_recipes`アソシエーションを追加
  - `Recipe`モデルに`favorite_recipes`、`favorited_by_users`アソシエーションを追加

  #### API実装
  - `Api::V1::FavoriteRecipesController`を作成
    - `GET /api/v1/favorite_recipes` - お気に入り一覧取得（ページネーション対応）
    - `POST /api/v1/favorite_recipes` - お気に入り追加（重複時422エラー）
    - `DELETE /api/v1/favorite_recipes/:id` - お気に入り削除
  - レスポンスにレシピ詳細情報を含む（タイトル、調理時間、難易度、人数）

  ### 編集ファイル

  #### 新規作成
  - `backend/db/migrate/20251003014326_create_favorite_recipes.rb`
  - `backend/app/models/favorite_recipe.rb`
  - `backend/app/controllers/api/v1/favorite_recipes_controller.rb`
  - `backend/spec/factories/favorite_recipes.rb`
  - `backend/spec/models/favorite_recipe_spec.rb`
  - `backend/spec/requests/api/v1/favorite_recipes_spec.rb`

  #### 編集
  - `backend/app/models/user.rb` - お気に入り関連アソシエーション追加
  - `backend/app/models/recipe.rb` - お気に入り関連アソシエーション追加
  - `backend/config/routes.rb` - favorite_recipesルーティング追加、shopping_lists改善
  - `backend/db/schema.rb` - favorite_recipesテーブル追加