### PR TITLE
feature/issue 27 settings screen

### DIFF
--- a/backend/app/controllers/api/v1/users/emails_controller.rb
+++ b/backend/app/controllers/api/v1/users/emails_controller.rb
@@ -1,0 +1,23 @@
+class Api::V1::Users::EmailsController < ApplicationController
+  before_action :authenticate_user!
+
+  # POST /api/v1/users/change_email
+  def create
+    unless current_user.valid_password?(email_params[:current_password])
+      render json: { error: "パスワードが正しくありません" }, status: :unauthorized
+      return
+    end
+
+    if current_user.update(email: email_params[:email])
+      render json: { message: "メールアドレスを変更しました。確認メールを送信しました" }
+    else
+      render json: { errors: current_user.errors.messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def email_params
+    params.require(:email_change).permit(:email, :current_password)
+  end
+end

--- a/backend/app/controllers/api/v1/users/passwords_controller.rb
+++ b/backend/app/controllers/api/v1/users/passwords_controller.rb
@@ -1,0 +1,26 @@
+class Api::V1::Users::PasswordsController < ApplicationController
+  before_action :authenticate_user!
+
+  # POST /api/v1/users/change_password
+  def create
+    unless current_user.valid_password?(password_params[:current_password])
+      render json: { error: "現在のパスワードが正しくありません" }, status: :unauthorized
+      return
+    end
+
+    if current_user.update(
+      password: password_params[:new_password],
+      password_confirmation: password_params[:new_password_confirmation]
+    )
+      render json: { message: "パスワードを変更しました。セキュリティのため再ログインしてください" }
+    else
+      render json: { errors: current_user.errors.messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def password_params
+    params.require(:password).permit(:current_password, :new_password, :new_password_confirmation)
+  end
+end

--- a/backend/app/controllers/api/v1/users/profiles_controller.rb
+++ b/backend/app/controllers/api/v1/users/profiles_controller.rb
@@ -1,0 +1,27 @@
+class Api::V1::Users::ProfilesController < ApplicationController
+  before_action :authenticate_user!
+
+  # GET /api/v1/users/profile
+  def show
+    render json: {
+      name: current_user.name,
+      email: current_user.email,
+      provider: current_user.provider
+    }
+  end
+
+  # PATCH /api/v1/users/profile
+  def update
+    if current_user.update(profile_params)
+      render json: { message: "プロフィールを更新しました" }
+    else
+      render json: { errors: current_user.errors.messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def profile_params
+    params.require(:profile).permit(:name)
+  end
+end

--- a/backend/app/controllers/api/v1/users/settings_controller.rb
+++ b/backend/app/controllers/api/v1/users/settings_controller.rb
@@ -1,0 +1,35 @@
+class Api::V1::Users::SettingsController < ApplicationController
+  before_action :authenticate_user!
+
+  # GET /api/v1/users/settings
+  def show
+    setting = current_user.setting
+    render json: {
+      default_servings: setting.default_servings,
+      recipe_difficulty: setting.recipe_difficulty,
+      cooking_time: setting.cooking_time,
+      shopping_frequency: setting.shopping_frequency
+    }
+  end
+
+  # PATCH /api/v1/users/settings
+  def update
+    setting = current_user.setting
+    if setting.update(settings_params)
+      render json: { message: "設定を保存しました" }
+    else
+      render json: { errors: setting.errors.messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def settings_params
+    params.require(:settings).permit(
+      :default_servings,
+      :recipe_difficulty,
+      :cooking_time,
+      :shopping_frequency
+    )
+  end
+end

--- a/backend/app/models/setting.rb
+++ b/backend/app/models/setting.rb
@@ -1,0 +1,15 @@
+class Setting < ApplicationRecord
+  belongs_to :user
+
+  # デフォルト値を明示的に定義
+  attribute :default_servings, :integer, default: 2
+  attribute :recipe_difficulty, :string, default: "medium"
+  attribute :cooking_time, :integer, default: 30
+  attribute :shopping_frequency, :string, default: "2-3日に1回"
+
+  # バリデーション
+  validates :recipe_difficulty, inclusion: { in: %w[easy medium hard] }
+  validates :shopping_frequency, inclusion: { in: [ "毎日", "2-3日に1回", "週に1回", "まとめ買い" ] }
+  validates :default_servings, numericality: { greater_than: 0, less_than_or_equal_to: 10 }
+  validates :cooking_time, inclusion: { in: [ 15, 30, 60, 999 ] }
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -14,6 +14,7 @@ class User < ApplicationRecord
 
   # Associations
   has_one :line_account, dependent: :destroy
+  has_one :setting, dependent: :destroy
   has_many :fridge_images, dependent: :destroy
   has_many :user_ingredients, dependent: :destroy
   has_many :ingredients, through: :user_ingredients
@@ -22,6 +23,9 @@ class User < ApplicationRecord
   has_many :shopping_lists, dependent: :destroy
   has_many :favorite_recipes, dependent: :destroy
   has_many :favorited_recipes, through: :favorite_recipes, source: :recipe
+
+  # Callbacks
+  after_create :build_default_setting, if: -> { setting.nil? }
 
   # Validations
   validates :name, presence: true, length: { maximum: 50 }
@@ -37,5 +41,14 @@ class User < ApplicationRecord
     end
 
     { "email" => email, "confirmed" => is_confirmed }
+  end
+
+  private
+
+  def build_default_setting
+    create_setting!
+  rescue ActiveRecord::RecordInvalid => e
+    Rails.logger.error("Failed to create default setting for user #{id}: #{e.message}")
+    true
   end
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -69,6 +69,14 @@ Rails.application.routes.draw do
           end
         end
       end
+
+      # User settings
+      namespace :users do
+        resource :profile, only: [ :show, :update ]
+        resource :settings, only: [ :show, :update ]
+        post "change_password", to: "passwords#create"
+        post "change_email", to: "emails#create"
+      end
     end
   end
 

--- a/backend/db/migrate/20251004121949_create_settings.rb
+++ b/backend/db/migrate/20251004121949_create_settings.rb
@@ -1,0 +1,25 @@
+class CreateSettings < ActiveRecord::Migration[7.2]
+  def up
+    create_table :settings do |t|
+      t.references :user, null: false, foreign_key: true, index: { unique: true }, comment: "ユーザーID"
+      t.integer :default_servings, default: 2, null: false, comment: "デフォルトの人数"
+      t.string :recipe_difficulty, default: "medium", comment: "レシピの難易度（easy/medium/hard）"
+      t.integer :cooking_time, default: 30, null: false, comment: "調理時間の目安（分）"
+      t.string :shopping_frequency, default: "2-3日に1回", comment: "買い物の頻度"
+
+      t.timestamps
+    end
+
+    # 既存ユーザー全員分のデフォルトレコード作成（生SQL）
+    execute <<-SQL
+      INSERT INTO settings (user_id, default_servings, recipe_difficulty, cooking_time, shopping_frequency, created_at, updated_at)
+      SELECT id, 2, 'medium', 30, '2-3日に1回', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+      FROM users
+      WHERE NOT EXISTS (SELECT 1 FROM settings WHERE settings.user_id = users.id)
+    SQL
+  end
+
+  def down
+    drop_table :settings
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_03_071608) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_04_121949) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -121,6 +121,17 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_03_071608) do
     t.index ["user_id"], name: "index_recipes_on_user_id"
   end
 
+  create_table "settings", force: :cascade do |t|
+    t.bigint "user_id", null: false, comment: "ユーザーID"
+    t.integer "default_servings", default: 2, null: false, comment: "デフォルトの人数"
+    t.string "recipe_difficulty", default: "medium", comment: "レシピの難易度（easy/medium/hard）"
+    t.integer "cooking_time", default: 30, null: false, comment: "調理時間の目安（分）"
+    t.string "shopping_frequency", default: "2-3日に1回", comment: "買い物の頻度"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_settings_on_user_id", unique: true
+  end
+
   create_table "shopping_list_items", force: :cascade do |t|
     t.bigint "shopping_list_id", null: false, comment: "所属する買い物リスト"
     t.bigint "ingredient_id", comment: "購入する食材"
@@ -201,6 +212,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_03_071608) do
   add_foreign_key "recipe_ingredients", "ingredients"
   add_foreign_key "recipe_ingredients", "recipes", on_delete: :cascade
   add_foreign_key "recipes", "users"
+  add_foreign_key "settings", "users"
   add_foreign_key "shopping_list_items", "ingredients"
   add_foreign_key "shopping_list_items", "shopping_lists"
   add_foreign_key "shopping_lists", "recipes"

--- a/backend/spec/factories/favorite_recipes.rb
+++ b/backend/spec/factories/favorite_recipes.rb
@@ -4,4 +4,3 @@ FactoryBot.define do
     recipe { association :recipe, user: user }
   end
 end
-

--- a/backend/spec/factories/settings.rb
+++ b/backend/spec/factories/settings.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :setting do
+    association :user
+    default_servings { 2 }
+    recipe_difficulty { "medium" }
+    cooking_time { 30 }
+    shopping_frequency { "2-3日に1回" }
+  end
+end

--- a/backend/spec/models/favorite_recipe_spec.rb
+++ b/backend/spec/models/favorite_recipe_spec.rb
@@ -43,4 +43,3 @@ RSpec.describe FavoriteRecipe, type: :model do
     end
   end
 end
-

--- a/backend/spec/models/setting_spec.rb
+++ b/backend/spec/models/setting_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe Setting, type: :model do
+  let(:user) { create(:user) }
+
+  describe "アソシエーション" do
+    it { is_expected.to belong_to(:user) }
+  end
+
+  describe "バリデーション" do
+    subject { build(:setting, user: user) }
+
+    it { is_expected.to validate_inclusion_of(:recipe_difficulty).in_array(%w[easy medium hard]) }
+    it { is_expected.to validate_inclusion_of(:shopping_frequency).in_array([ "毎日", "2-3日に1回", "週に1回", "まとめ買い" ]) }
+    it { is_expected.to validate_numericality_of(:default_servings).is_greater_than(0).is_less_than_or_equal_to(10) }
+    it { is_expected.to validate_inclusion_of(:cooking_time).in_array([ 15, 30, 60, 999 ]) }
+  end
+
+  describe "デフォルト値" do
+    it "正しいデフォルト値を持つ" do
+      setting = Setting.new
+      expect(setting.default_servings).to eq(2)
+      expect(setting.recipe_difficulty).to eq("medium")
+      expect(setting.cooking_time).to eq(30)
+      expect(setting.shopping_frequency).to eq("2-3日に1回")
+    end
+  end
+end

--- a/backend/spec/models/user_spec.rb
+++ b/backend/spec/models/user_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe User, type: :model do
+  describe "アソシエーション" do
+    it { is_expected.to have_one(:line_account).dependent(:destroy) }
+    it { is_expected.to have_one(:setting).dependent(:destroy) }
+    it { is_expected.to have_many(:fridge_images).dependent(:destroy) }
+    it { is_expected.to have_many(:user_ingredients).dependent(:destroy) }
+    it { is_expected.to have_many(:recipes).dependent(:destroy) }
+    it { is_expected.to have_many(:recipe_histories).dependent(:destroy) }
+    it { is_expected.to have_many(:shopping_lists).dependent(:destroy) }
+    it { is_expected.to have_many(:favorite_recipes).dependent(:destroy) }
+  end
+
+  describe "バリデーション" do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_length_of(:name).is_at_most(50) }
+    it { is_expected.to validate_inclusion_of(:provider).in_array(%w[email line]) }
+  end
+
+  describe "コールバック" do
+    describe "after_create :build_default_setting" do
+      it "ユーザー作成時にデフォルトのsettingが作成される" do
+        user = create(:user)
+        expect(user.setting).to be_present
+        expect(user.setting.default_servings).to eq(2)
+        expect(user.setting.recipe_difficulty).to eq("medium")
+        expect(user.setting.cooking_time).to eq(30)
+        expect(user.setting.shopping_frequency).to eq("2-3日に1回")
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/favorite_recipes_spec.rb
+++ b/backend/spec/requests/api/v1/favorite_recipes_spec.rb
@@ -167,4 +167,3 @@ RSpec.describe "Api::V1::FavoriteRecipes", type: :request do
     end
   end
 end
-

--- a/backend/spec/requests/api/v1/users/emails_spec.rb
+++ b/backend/spec/requests/api/v1/users/emails_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Users::Emails", type: :request do
+  let(:user) { create(:user, :confirmed, password: "password123", password_confirmation: "password123") }
+
+  def auth_header_for(user)
+    post "/api/v1/auth/login", params: { user: { email: user.email, password: "password123" } }, as: :json
+    { "Authorization" => response.headers["Authorization"] }
+  end
+
+  describe "POST /api/v1/users/change_email" do
+    let(:valid_params) do
+      {
+        email_change: {
+          email: "newemail@example.com",
+          current_password: "password123"
+        }
+      }
+    end
+
+    it "認証なしで401を返す" do
+      post "/api/v1/users/change_email", params: valid_params, as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "有効なパラメータでメールアドレスを変更する" do
+      headers = auth_header_for(user)
+      post "/api/v1/users/change_email", params: valid_params, headers: headers, as: :json
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["message"]).to eq("メールアドレスを変更しました。確認メールを送信しました")
+      user.reload
+      expect(user.email).to eq("newemail@example.com")
+    end
+
+    it "current_passwordが不一致の場合401を返す" do
+      headers = auth_header_for(user)
+      invalid_params = {
+        email_change: {
+          email: "newemail@example.com",
+          current_password: "wrongpassword"
+        }
+      }
+      post "/api/v1/users/change_email", params: invalid_params, headers: headers, as: :json
+      expect(response).to have_http_status(:unauthorized)
+      body = JSON.parse(response.body)
+      expect(body["error"]).to eq("パスワードが正しくありません")
+    end
+
+    it "emailが重複する場合422を返す" do
+      existing_user = create(:user, :confirmed, email: "existing@example.com")
+      headers = auth_header_for(user)
+      invalid_params = {
+        email_change: {
+          email: "existing@example.com",
+          current_password: "password123"
+        }
+      }
+      post "/api/v1/users/change_email", params: invalid_params, headers: headers, as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+      body = JSON.parse(response.body)
+      expect(body["errors"]).to have_key("email")
+    end
+
+    it "emailの形式が不正な場合422を返す" do
+      headers = auth_header_for(user)
+      invalid_params = {
+        email_change: {
+          email: "invalid-email",
+          current_password: "password123"
+        }
+      }
+      post "/api/v1/users/change_email", params: invalid_params, headers: headers, as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+      body = JSON.parse(response.body)
+      expect(body["errors"]).to have_key("email")
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/users/passwords_spec.rb
+++ b/backend/spec/requests/api/v1/users/passwords_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Users::Passwords", type: :request do
+  let(:user) { create(:user, :confirmed, password: "password123", password_confirmation: "password123") }
+
+  def auth_header_for(user)
+    post "/api/v1/auth/login", params: { user: { email: user.email, password: "password123" } }, as: :json
+    { "Authorization" => response.headers["Authorization"] }
+  end
+
+  describe "POST /api/v1/users/change_password" do
+    let(:valid_params) do
+      {
+        password: {
+          current_password: "password123",
+          new_password: "newpassword123",
+          new_password_confirmation: "newpassword123"
+        }
+      }
+    end
+
+    it "認証なしで401を返す" do
+      post "/api/v1/users/change_password", params: valid_params, as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "有効なパラメータでパスワードを変更する" do
+      headers = auth_header_for(user)
+      post "/api/v1/users/change_password", params: valid_params, headers: headers, as: :json
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["message"]).to eq("パスワードを変更しました。セキュリティのため再ログインしてください")
+      user.reload
+      expect(user.valid_password?("newpassword123")).to be true
+    end
+
+    it "current_passwordが不一致の場合401を返す" do
+      headers = auth_header_for(user)
+      invalid_params = {
+        password: {
+          current_password: "wrongpassword",
+          new_password: "newpassword123",
+          new_password_confirmation: "newpassword123"
+        }
+      }
+      post "/api/v1/users/change_password", params: invalid_params, headers: headers, as: :json
+      expect(response).to have_http_status(:unauthorized)
+      body = JSON.parse(response.body)
+      expect(body["error"]).to eq("現在のパスワードが正しくありません")
+    end
+
+    it "new_passwordが短すぎる場合422を返す" do
+      headers = auth_header_for(user)
+      invalid_params = {
+        password: {
+          current_password: "password123",
+          new_password: "short",
+          new_password_confirmation: "short"
+        }
+      }
+      post "/api/v1/users/change_password", params: invalid_params, headers: headers, as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+      body = JSON.parse(response.body)
+      expect(body["errors"]).to have_key("password")
+    end
+
+    it "new_password_confirmationが不一致の場合422を返す" do
+      headers = auth_header_for(user)
+      invalid_params = {
+        password: {
+          current_password: "password123",
+          new_password: "newpassword123",
+          new_password_confirmation: "differentpassword"
+        }
+      }
+      post "/api/v1/users/change_password", params: invalid_params, headers: headers, as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+      body = JSON.parse(response.body)
+      expect(body["errors"]).to have_key("password_confirmation")
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/users/profiles_spec.rb
+++ b/backend/spec/requests/api/v1/users/profiles_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Users::Profiles", type: :request do
+  let(:user) { create(:user, :confirmed) }
+
+  def auth_header_for(user)
+    post "/api/v1/auth/login", params: { user: { email: user.email, password: "password123" } }, as: :json
+    { "Authorization" => response.headers["Authorization"] }
+  end
+
+  describe "GET /api/v1/users/profile" do
+    it "認証なしで401を返す" do
+      get "/api/v1/users/profile", as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "認証済みユーザーのプロフィールを返す" do
+      headers = auth_header_for(user)
+      get "/api/v1/users/profile", headers: headers, as: :json
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["name"]).to eq(user.name)
+      expect(body["email"]).to eq(user.email)
+      expect(body["provider"]).to eq(user.provider)
+    end
+  end
+
+  describe "PATCH /api/v1/users/profile" do
+    let(:valid_params) { { profile: { name: "新しい名前" } } }
+
+    it "認証なしで401を返す" do
+      patch "/api/v1/users/profile", params: valid_params, as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "有効なパラメータでプロフィールを更新する" do
+      headers = auth_header_for(user)
+      patch "/api/v1/users/profile", params: valid_params, headers: headers, as: :json
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["message"]).to eq("プロフィールを更新しました")
+      user.reload
+      expect(user.name).to eq("新しい名前")
+    end
+
+    it "nameが空の場合422を返す" do
+      headers = auth_header_for(user)
+      invalid_params = { profile: { name: "" } }
+      patch "/api/v1/users/profile", params: invalid_params, headers: headers, as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+      body = JSON.parse(response.body)
+      expect(body["errors"]).to have_key("name")
+    end
+
+    it "nameが長すぎる場合422を返す" do
+      headers = auth_header_for(user)
+      invalid_params = { profile: { name: "a" * 51 } }
+      patch "/api/v1/users/profile", params: invalid_params, headers: headers, as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+      body = JSON.parse(response.body)
+      expect(body["errors"]).to have_key("name")
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/users/settings_spec.rb
+++ b/backend/spec/requests/api/v1/users/settings_spec.rb
@@ -1,0 +1,106 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Users::Settings", type: :request do
+  let(:user) { create(:user, :confirmed) }
+
+  def auth_header_for(user)
+    post "/api/v1/auth/login", params: { user: { email: user.email, password: "password123" } }, as: :json
+    { "Authorization" => response.headers["Authorization"] }
+  end
+
+  describe "GET /api/v1/users/settings" do
+    it "認証なしで401を返す" do
+      get "/api/v1/users/settings", as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "認証済みユーザーの設定を返す" do
+      headers = auth_header_for(user)
+      get "/api/v1/users/settings", headers: headers, as: :json
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body).to have_key("default_servings")
+      expect(body).to have_key("recipe_difficulty")
+      expect(body).to have_key("cooking_time")
+      expect(body).to have_key("shopping_frequency")
+      expect(body["default_servings"]).to eq(2)
+      expect(body["recipe_difficulty"]).to eq("medium")
+    end
+  end
+
+  describe "PATCH /api/v1/users/settings" do
+    let(:valid_params) do
+      {
+        settings: {
+          default_servings: 4,
+          recipe_difficulty: "easy",
+          cooking_time: 60,
+          shopping_frequency: "週に1回"
+        }
+      }
+    end
+
+    it "認証なしで401を返す" do
+      patch "/api/v1/users/settings", params: valid_params, as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "有効なパラメータで設定を更新する" do
+      headers = auth_header_for(user)
+      patch "/api/v1/users/settings", params: valid_params, headers: headers, as: :json
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["message"]).to eq("設定を保存しました")
+      user.reload
+      expect(user.setting.default_servings).to eq(4)
+      expect(user.setting.recipe_difficulty).to eq("easy")
+      expect(user.setting.cooking_time).to eq(60)
+      expect(user.setting.shopping_frequency).to eq("週に1回")
+    end
+
+    it "recipe_difficultyが不正な値の場合422を返す" do
+      headers = auth_header_for(user)
+      invalid_params = { settings: { recipe_difficulty: "invalid" } }
+      patch "/api/v1/users/settings", params: invalid_params, headers: headers, as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+      body = JSON.parse(response.body)
+      expect(body["errors"]).to have_key("recipe_difficulty")
+    end
+
+    it "default_servingsが範囲外（0）の場合422を返す" do
+      headers = auth_header_for(user)
+      invalid_params = { settings: { default_servings: 0 } }
+      patch "/api/v1/users/settings", params: invalid_params, headers: headers, as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+      body = JSON.parse(response.body)
+      expect(body["errors"]).to have_key("default_servings")
+    end
+
+    it "default_servingsが範囲外（11）の場合422を返す" do
+      headers = auth_header_for(user)
+      invalid_params = { settings: { default_servings: 11 } }
+      patch "/api/v1/users/settings", params: invalid_params, headers: headers, as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+      body = JSON.parse(response.body)
+      expect(body["errors"]).to have_key("default_servings")
+    end
+
+    it "cooking_timeが不正な値（45）の場合422を返す" do
+      headers = auth_header_for(user)
+      invalid_params = { settings: { cooking_time: 45 } }
+      patch "/api/v1/users/settings", params: invalid_params, headers: headers, as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+      body = JSON.parse(response.body)
+      expect(body["errors"]).to have_key("cooking_time")
+    end
+
+    it "shopping_frequencyが不正な値の場合422を返す" do
+      headers = auth_header_for(user)
+      invalid_params = { settings: { shopping_frequency: "毎週" } }
+      patch "/api/v1/users/settings", params: invalid_params, headers: headers, as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+      body = JSON.parse(response.body)
+      expect(body["errors"]).to have_key("shopping_frequency")
+    end
+  end
+end

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -1,0 +1,70 @@
+import { apiClient } from './client';
+
+export interface UserProfile {
+  name: string;
+  email: string;
+  provider: string;
+}
+
+export interface UserSettings {
+  default_servings: number;
+  recipe_difficulty: 'easy' | 'medium' | 'hard';
+  cooking_time: number;
+  shopping_frequency: string;
+}
+
+export interface UpdateProfileData {
+  name: string;
+}
+
+export interface UpdateSettingsData {
+  default_servings?: number;
+  recipe_difficulty?: 'easy' | 'medium' | 'hard';
+  cooking_time?: number;
+  shopping_frequency?: string;
+}
+
+export interface ChangePasswordData {
+  current_password: string;
+  new_password: string;
+  new_password_confirmation: string;
+}
+
+export interface ChangeEmailData {
+  email: string;
+  current_password: string;
+}
+
+export interface MessageResponse {
+  message: string;
+}
+
+export const getUserProfile = async (): Promise<UserProfile> => {
+  const response = await apiClient.get('/users/profile');
+  return response.data;
+};
+
+export const updateUserProfile = async (data: UpdateProfileData): Promise<MessageResponse> => {
+  const response = await apiClient.patch('/users/profile', { profile: data });
+  return response.data;
+};
+
+export const getUserSettings = async (): Promise<UserSettings> => {
+  const response = await apiClient.get('/users/settings');
+  return response.data;
+};
+
+export const updateUserSettings = async (data: UpdateSettingsData): Promise<MessageResponse> => {
+  const response = await apiClient.patch('/users/settings', { settings: data });
+  return response.data;
+};
+
+export const changePassword = async (data: ChangePasswordData): Promise<MessageResponse> => {
+  const response = await apiClient.post('/users/change_password', { password: data });
+  return response.data;
+};
+
+export const changeEmail = async (data: ChangeEmailData): Promise<MessageResponse> => {
+  const response = await apiClient.post('/users/change_email', { email_change: data });
+  return response.data;
+};

--- a/frontend/src/constants/settings.ts
+++ b/frontend/src/constants/settings.ts
@@ -1,0 +1,19 @@
+export const DIFFICULTY_OPTIONS = [
+  { value: 'easy', label: 'かんたん' },
+  { value: 'medium', label: 'ふつう' },
+  { value: 'hard', label: 'むずかしい' }
+] as const;
+
+export const COOKING_TIME_OPTIONS = [
+  { value: 15, label: '15分以内' },
+  { value: 30, label: '30分以内' },
+  { value: 60, label: '1時間以内' },
+  { value: 999, label: '時間制限なし' }
+] as const;
+
+export const SHOPPING_FREQUENCY_OPTIONS = [
+  { value: '毎日', label: '毎日' },
+  { value: '2-3日に1回', label: '2-3日に1回' },
+  { value: '週に1回', label: '週に1回' },
+  { value: 'まとめ買い', label: 'まとめ買い' }
+] as const;

--- a/frontend/src/pages/Settings/Settings.tsx
+++ b/frontend/src/pages/Settings/Settings.tsx
@@ -34,62 +34,65 @@ const Settings: React.FC = () => {
         setProfile(profileData);
         setSettings(settingsData);
         setProfileForm({ name: profileData.name });
-      } catch (error: any) {
-        if (error.response?.status === 401) {
+      } catch (error) {
+        const err = error as { response?: { status?: number } };
+        if (err.response?.status === 401) {
           showToast('セッションが切れました。再度ログインしてください', 'error');
           logout();
         } else {
           showToast('データの取得に失敗しました', 'error');
         }
       } finally {
-        setLoading({ ...loading, profile: false, settings: false });
+        setLoading((prev) => ({ ...prev, profile: false, settings: false }));
       }
     };
 
     fetchData();
-  }, []);
+  }, [logout, showToast]);
 
   const handleProfileSave = async () => {
-    setLoading({ ...loading, saving: true });
+    setLoading((prev) => ({ ...prev, saving: true }));
     setErrors({});
     try {
       const response = await updateUserProfile({ name: profileForm.name });
       showToast(response.message, 'success');
       setProfile({ ...profile!, name: profileForm.name });
-    } catch (error: any) {
-      if (error.response?.status === 422) {
-        setErrors(error.response.data.errors);
+    } catch (error) {
+      const err = error as { response?: { status?: number; data?: { errors?: Record<string, string[]> } } };
+      if (err.response?.status === 422) {
+        setErrors(err.response.data?.errors || {});
         showToast('入力内容を確認してください', 'error');
-      } else if (error.response?.status === 401) {
+      } else if (err.response?.status === 401) {
         showToast('セッションが切れました。再度ログインしてください', 'error');
         logout();
       } else {
         showToast('保存に失敗しました', 'error');
       }
     } finally {
-      setLoading({ ...loading, saving: false });
+      setLoading((prev) => ({ ...prev, saving: false }));
     }
   };
 
   const handleSettingsSave = async () => {
     if (!settings) return;
-    setLoading({ ...loading, saving: true });
+    setLoading((prev) => ({ ...prev, saving: true }));
     setErrors({});
     try {
       const response = await updateUserSettings(settings);
       showToast(response.message, 'success');
-    } catch (error: any) {
-      if (error.response?.status === 422) {
-        setErrors(error.response.data.errors);
+    } catch (error) {
+      const err = error as { response?: { status?: number; data?: { errors?: Record<string, string[]> } } };
+      if (err.response?.status === 422) {
+        setErrors(err.response.data?.errors || {});
         showToast('入力内容を確認してください', 'error');
-      } else if (error.response?.status === 401) {
+      } else if (err.response?.status === 401) {
         showToast('セッションが切れました。再度ログインしてください', 'error');
         logout();
       } else {
         showToast('保存に失敗しました', 'error');
       }
     } finally {
-      setLoading({ ...loading, saving: false });
+      setLoading((prev) => ({ ...prev, saving: false }));
     }
   };
 

--- a/frontend/test/Settings.test.tsx
+++ b/frontend/test/Settings.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { BrowserRouter } from 'react-router-dom'
+import Settings from '../src/pages/Settings/Settings'
+import * as usersApi from '../src/api/users'
+import * as useAuthHook from '../src/hooks/useAuth'
+import * as useToastHook from '../src/hooks/useToast'
+
+vi.mock('../src/api/users')
+vi.mock('../src/hooks/useAuth')
+vi.mock('../src/hooks/useToast')
+
+const mockShowToast = vi.fn()
+const mockLogout = vi.fn()
+
+describe('Settings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    vi.mocked(useAuthHook.useAuth).mockReturnValue({
+      isLoggedIn: true,
+      isAuthResolved: true,
+      user: { id: 1, name: 'Test User', email: 'test@example.com', created_at: '', updated_at: '' },
+      login: vi.fn(),
+      logout: mockLogout,
+      setAuthState: vi.fn(),
+    })
+
+    vi.mocked(useToastHook.useToast).mockReturnValue({
+      showToast: mockShowToast,
+    })
+
+    vi.mocked(usersApi.getUserProfile).mockResolvedValue({
+      name: 'Test User',
+      email: 'test@example.com',
+      provider: 'email',
+    })
+
+    vi.mocked(usersApi.getUserSettings).mockResolvedValue({
+      default_servings: 2,
+      recipe_difficulty: 'medium',
+      cooking_time: 30,
+      shopping_frequency: '2-3日に1回',
+    })
+  })
+
+  const renderSettings = () => {
+    return render(
+      <BrowserRouter>
+        <Settings />
+      </BrowserRouter>
+    )
+  }
+
+  it('設定画面が表示される', async () => {
+    renderSettings()
+
+    await waitFor(() => {
+      expect(usersApi.getUserProfile).toHaveBeenCalled()
+      expect(usersApi.getUserSettings).toHaveBeenCalled()
+    })
+  })
+
+  it('保存時にAPIが呼ばれる', async () => {
+    const user = userEvent.setup()
+    vi.mocked(usersApi.updateUserProfile).mockResolvedValue({
+      message: 'プロフィールを更新しました',
+    })
+    vi.mocked(usersApi.updateUserSettings).mockResolvedValue({
+      message: '設定を保存しました',
+    })
+
+    renderSettings()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '変更を保存' })).toBeInTheDocument()
+    })
+
+    const saveButton = screen.getByRole('button', { name: '変更を保存' })
+    await user.click(saveButton)
+
+    await waitFor(() => {
+      expect(usersApi.updateUserSettings).toHaveBeenCalled()
+    })
+  })
+})

--- a/liff/src/api/users.ts
+++ b/liff/src/api/users.ts
@@ -1,0 +1,49 @@
+import { apiClient } from './client';
+
+export interface UserProfile {
+  name: string;
+  email: string;
+  provider: string;
+}
+
+export interface UserSettings {
+  default_servings: number;
+  recipe_difficulty: 'easy' | 'medium' | 'hard';
+  cooking_time: number;
+  shopping_frequency: string;
+}
+
+export interface UpdateProfileData {
+  name: string;
+}
+
+export interface UpdateSettingsData {
+  default_servings?: number;
+  recipe_difficulty?: 'easy' | 'medium' | 'hard';
+  cooking_time?: number;
+  shopping_frequency?: string;
+}
+
+export interface MessageResponse {
+  message: string;
+}
+
+export const getUserProfile = async (): Promise<UserProfile> => {
+  const response = await apiClient.get('/users/profile');
+  return response.data;
+};
+
+export const updateUserProfile = async (data: UpdateProfileData): Promise<MessageResponse> => {
+  const response = await apiClient.patch('/users/profile', { profile: data });
+  return response.data;
+};
+
+export const getUserSettings = async (): Promise<UserSettings> => {
+  const response = await apiClient.get('/users/settings');
+  return response.data;
+};
+
+export const updateUserSettings = async (data: UpdateSettingsData): Promise<MessageResponse> => {
+  const response = await apiClient.patch('/users/settings', { settings: data });
+  return response.data;
+};

--- a/liff/src/constants/settings.ts
+++ b/liff/src/constants/settings.ts
@@ -1,0 +1,19 @@
+export const DIFFICULTY_OPTIONS = [
+  { value: 'easy', label: 'かんたん' },
+  { value: 'medium', label: 'ふつう' },
+  { value: 'hard', label: 'むずかしい' }
+] as const;
+
+export const COOKING_TIME_OPTIONS = [
+  { value: 15, label: '15分以内' },
+  { value: 30, label: '30分以内' },
+  { value: 60, label: '1時間以内' },
+  { value: 999, label: '時間制限なし' }
+] as const;
+
+export const SHOPPING_FREQUENCY_OPTIONS = [
+  { value: '毎日', label: '毎日' },
+  { value: '2-3日に1回', label: '2-3日に1回' },
+  { value: '週に1回', label: '週に1回' },
+  { value: 'まとめ買い', label: 'まとめ買い' }
+] as const;

--- a/liff/src/pages/Settings/Settings.tsx
+++ b/liff/src/pages/Settings/Settings.tsx
@@ -23,25 +23,26 @@ const Settings: React.FC = () => {
         setProfile(profileData);
         setSettings(settingsData);
         setProfileForm({ name: profileData.name });
-      } catch (error: any) {
-        if (error.response?.status === 401) {
+      } catch (error) {
+        const err = error as { response?: { status?: number } };
+        if (err.response?.status === 401) {
           setMessage({ type: 'error', text: 'セッションが切れました。再度ログインしてください' });
           setTimeout(() => logout(), 2000);
         } else {
           setMessage({ type: 'error', text: 'データの取得に失敗しました' });
         }
       } finally {
-        setLoading({ ...loading, data: false });
+        setLoading((prev) => ({ ...prev, data: false }));
       }
     };
 
     fetchData();
-  }, []);
+  }, [logout]);
 
   const handleSave = async () => {
     if (!settings) return;
 
-    setLoading({ ...loading, saving: true });
+    setLoading((prev) => ({ ...prev, saving: true }));
     setErrors({});
     setMessage(null);
 
@@ -55,18 +56,19 @@ const Settings: React.FC = () => {
         setProfile({ ...profile, name: profileForm.name });
       }
       setTimeout(() => setMessage(null), 3000);
-    } catch (error: any) {
-      if (error.response?.status === 422) {
-        setErrors(error.response.data.errors);
+    } catch (error) {
+      const err = error as { response?: { status?: number; data?: { errors?: Record<string, string[]> } } };
+      if (err.response?.status === 422) {
+        setErrors(err.response.data?.errors || {});
         setMessage({ type: 'error', text: '入力内容を確認してください' });
-      } else if (error.response?.status === 401) {
+      } else if (err.response?.status === 401) {
         setMessage({ type: 'error', text: 'セッションが切れました。再度ログインしてください' });
         setTimeout(() => logout(), 2000);
       } else {
         setMessage({ type: 'error', text: '保存に失敗しました' });
       }
     } finally {
-      setLoading({ ...loading, saving: false });
+      setLoading((prev) => ({ ...prev, saving: false }));
     }
   };
 

--- a/liff/src/pages/Settings/Settings.tsx
+++ b/liff/src/pages/Settings/Settings.tsx
@@ -1,14 +1,266 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react';
+import { getUserProfile, getUserSettings, updateUserProfile, updateUserSettings } from '../../api/users';
+import type { UserProfile, UserSettings } from '../../api/users';
+import { DIFFICULTY_OPTIONS, COOKING_TIME_OPTIONS, SHOPPING_FREQUENCY_OPTIONS } from '../../constants/settings';
+import { useAuth } from '../../hooks/useAuth';
 
 const Settings: React.FC = () => {
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [settings, setSettings] = useState<UserSettings | null>(null);
+  const [profileForm, setProfileForm] = useState({ name: '' });
+  const [loading, setLoading] = useState({ data: true, saving: false });
+  const [errors, setErrors] = useState<{ [key: string]: string[] }>({});
+  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const { logout } = useAuth();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const [profileData, settingsData] = await Promise.all([
+          getUserProfile(),
+          getUserSettings()
+        ]);
+        setProfile(profileData);
+        setSettings(settingsData);
+        setProfileForm({ name: profileData.name });
+      } catch (error: any) {
+        if (error.response?.status === 401) {
+          setMessage({ type: 'error', text: 'セッションが切れました。再度ログインしてください' });
+          setTimeout(() => logout(), 2000);
+        } else {
+          setMessage({ type: 'error', text: 'データの取得に失敗しました' });
+        }
+      } finally {
+        setLoading({ ...loading, data: false });
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  const handleSave = async () => {
+    if (!settings) return;
+
+    setLoading({ ...loading, saving: true });
+    setErrors({});
+    setMessage(null);
+
+    try {
+      await Promise.all([
+        updateUserProfile({ name: profileForm.name }),
+        updateUserSettings(settings)
+      ]);
+      setMessage({ type: 'success', text: '変更を保存しました' });
+      if (profile) {
+        setProfile({ ...profile, name: profileForm.name });
+      }
+      setTimeout(() => setMessage(null), 3000);
+    } catch (error: any) {
+      if (error.response?.status === 422) {
+        setErrors(error.response.data.errors);
+        setMessage({ type: 'error', text: '入力内容を確認してください' });
+      } else if (error.response?.status === 401) {
+        setMessage({ type: 'error', text: 'セッションが切れました。再度ログインしてください' });
+        setTimeout(() => logout(), 2000);
+      } else {
+        setMessage({ type: 'error', text: '保存に失敗しました' });
+      }
+    } finally {
+      setLoading({ ...loading, saving: false });
+    }
+  };
+
+  const handleCancel = () => {
+    if (profile) {
+      setProfileForm({ name: profile.name });
+    }
+    setErrors({});
+    setMessage(null);
+  };
+
+  if (loading.data) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-2xl font-bold text-gray-800 mb-6">設定</h1>
+        <div className="bg-white rounded-lg shadow-md p-6">
+          <div className="text-center py-8 text-gray-600">読み込み中...</div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="container mx-auto px-4 py-8">
       <h1 className="text-2xl font-bold text-gray-800 mb-6">設定</h1>
-      <div className="bg-white rounded-lg shadow-md p-6">
-        <p className="text-gray-600">設定項目が表示されます</p>
+
+      {message && (
+        <div className={`mb-4 p-3 rounded-lg ${
+          message.type === 'success' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
+        }`}>
+          {message.text}
+        </div>
+      )}
+
+      <div className="bg-white rounded-lg shadow-md p-6 space-y-8">
+        {/* プロフィール */}
+        <div>
+          <h2 className="text-lg font-bold text-gray-900 mb-4">プロフィール</h2>
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">お名前</label>
+              <input
+                type="text"
+                value={profileForm.name}
+                onChange={(e) => setProfileForm({ name: e.target.value })}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500 focus:border-transparent"
+              />
+              {errors.name && (
+                <p className="text-xs text-red-600 mt-1">{errors.name.join(', ')}</p>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">メールアドレス</label>
+              <input
+                type="email"
+                value={profile?.email || ''}
+                disabled
+                className="w-full px-3 py-2 border border-gray-300 rounded-md bg-gray-100 text-gray-600"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">プロバイダー</label>
+              <input
+                type="text"
+                value={profile?.provider === 'email' ? 'メール' : 'LINE'}
+                disabled
+                className="w-full px-3 py-2 border border-gray-300 rounded-md bg-gray-100 text-gray-600"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="border-t border-gray-200 pt-6"></div>
+
+        {/* 基本設定 */}
+        <div>
+          <h2 className="text-lg font-bold text-gray-900 mb-4">基本設定</h2>
+          {settings && (
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">家族の人数</label>
+                <input
+                  type="number"
+                  min="1"
+                  max="10"
+                  value={settings.default_servings}
+                  onChange={(e) => setSettings({ ...settings, default_servings: parseInt(e.target.value) })}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500 focus:border-transparent"
+                />
+                {errors.default_servings && (
+                  <p className="text-xs text-red-600 mt-1">{errors.default_servings.join(', ')}</p>
+                )}
+                <p className="text-xs text-gray-500 mt-1">レシピの分量計算に使用されます</p>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">レシピの難易度</label>
+                <select
+                  value={settings.recipe_difficulty}
+                  onChange={(e) => setSettings({ ...settings, recipe_difficulty: e.target.value as 'easy' | 'medium' | 'hard' })}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500 focus:border-transparent"
+                >
+                  {DIFFICULTY_OPTIONS.map(option => (
+                    <option key={option.value} value={option.value}>{option.label}</option>
+                  ))}
+                </select>
+                {errors.recipe_difficulty && (
+                  <p className="text-xs text-red-600 mt-1">{errors.recipe_difficulty.join(', ')}</p>
+                )}
+                <p className="text-xs text-gray-500 mt-1">あなたの料理スキルに合わせて調整</p>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">調理時間の目安</label>
+                <select
+                  value={settings.cooking_time}
+                  onChange={(e) => setSettings({ ...settings, cooking_time: parseInt(e.target.value) })}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500 focus:border-transparent"
+                >
+                  {COOKING_TIME_OPTIONS.map(option => (
+                    <option key={option.value} value={option.value}>{option.label}</option>
+                  ))}
+                </select>
+                {errors.cooking_time && (
+                  <p className="text-xs text-red-600 mt-1">{errors.cooking_time.join(', ')}</p>
+                )}
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">買い物の頻度</label>
+                <select
+                  value={settings.shopping_frequency}
+                  onChange={(e) => setSettings({ ...settings, shopping_frequency: e.target.value })}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500 focus:border-transparent"
+                >
+                  {SHOPPING_FREQUENCY_OPTIONS.map(option => (
+                    <option key={option.value} value={option.value}>{option.label}</option>
+                  ))}
+                </select>
+                {errors.shopping_frequency && (
+                  <p className="text-xs text-red-600 mt-1">{errors.shopping_frequency.join(', ')}</p>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="border-t border-gray-200 pt-6"></div>
+
+        {/* LINE連携状態 */}
+        <div>
+          <h2 className="text-lg font-bold text-gray-900 mb-4">LINE連携</h2>
+          <div className="p-4 bg-gray-50 rounded-lg">
+            <div className="flex items-center gap-2">
+              <div className="bg-green-500 text-white px-2 py-1 rounded text-sm font-bold">LINE</div>
+              <span className="text-sm text-gray-600">
+                {profile?.provider === 'line' ? '連携済み' : '未連携'}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="border-t border-gray-200 pt-6"></div>
+
+        {/* パスワード・メールアドレス変更 */}
+        <div>
+          <h2 className="text-lg font-bold text-gray-900 mb-4">アカウント管理</h2>
+          <p className="text-sm text-gray-600 mb-4">
+            パスワードやメールアドレスの変更は、Web版の設定画面から行えます
+          </p>
+        </div>
+
+        {/* 保存・キャンセルボタン */}
+        <div className="flex gap-3 pt-4">
+          <button
+            className="flex-1 px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 text-gray-700"
+            onClick={handleCancel}
+            disabled={loading.saving}
+          >
+            キャンセル
+          </button>
+          <button
+            className="flex-1 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:bg-gray-400"
+            onClick={handleSave}
+            disabled={loading.saving}
+          >
+            {loading.saving ? '保存中...' : '変更を保存'}
+          </button>
+        </div>
       </div>
     </div>
-  )
-}
+  );
+};
 
-export default Settings
+export default Settings;

--- a/liff/test/Settings.test.tsx
+++ b/liff/test/Settings.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BrowserRouter } from 'react-router-dom'
+import Settings from '../src/pages/Settings/Settings'
+import * as usersApi from '../src/api/users'
+import * as useAuthHook from '../src/hooks/useAuth'
+
+vi.mock('../src/api/users')
+vi.mock('../src/hooks/useAuth')
+
+const mockLogout = vi.fn()
+
+describe('Settings (LIFF)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    vi.mocked(useAuthHook.useAuth).mockReturnValue({
+      isInitialized: true,
+      isAuthenticated: true,
+      isInClient: true,
+      user: { userId: 'U123', displayName: 'Test User', pictureUrl: undefined },
+      login: vi.fn(),
+      logout: mockLogout,
+    })
+
+    vi.mocked(usersApi.getUserProfile).mockResolvedValue({
+      name: 'Test User',
+      email: 'test@example.com',
+      provider: 'line',
+    })
+
+    vi.mocked(usersApi.getUserSettings).mockResolvedValue({
+      default_servings: 2,
+      recipe_difficulty: 'medium',
+      cooking_time: 30,
+      shopping_frequency: '2-3日に1回',
+    })
+  })
+
+  const renderSettings = () => {
+    return render(
+      <BrowserRouter>
+        <Settings />
+      </BrowserRouter>
+    )
+  }
+
+  it('設定画面が表示される', async () => {
+    renderSettings()
+
+    await waitFor(() => {
+      expect(usersApi.getUserProfile).toHaveBeenCalled()
+      expect(usersApi.getUserSettings).toHaveBeenCalled()
+    })
+  })
+
+  it('保存時にAPIが呼ばれる', async () => {
+    const user = userEvent.setup()
+    vi.mocked(usersApi.updateUserProfile).mockResolvedValue({
+      message: 'プロフィールを更新しました',
+    })
+    vi.mocked(usersApi.updateUserSettings).mockResolvedValue({
+      message: '設定を保存しました',
+    })
+
+    renderSettings()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '変更を保存' })).toBeInTheDocument()
+    })
+
+    const saveButton = screen.getByRole('button', { name: '変更を保存' })
+    await user.click(saveButton)
+
+    await waitFor(() => {
+      expect(usersApi.updateUserProfile).toHaveBeenCalled()
+      expect(usersApi.updateUserSettings).toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
## 概要

  Issue #27「設定画面の実装」に対応し、ユーザーがプロフィール情報と基本設定を管理できる機能を実装した。

 ### 実装内容

 #### バックエンド

  データベース
  - Settingsテーブルを新規作成（1ユーザー1設定のユニーク制約）
  - 既存ユーザーへのデフォルト設定をマイグレーションで自動作成
  - UserモデルにSettingとの1対1リレーションを追加

  APIエンドポイント
  - GET/PATCH /api/v1/users/profile: プロフィール情報の取得・更新
  - GET/PATCH /api/v1/users/settings: 基本設定の取得・更新
  - POST /api/v1/users/change_password: パスワード変更（セキュリティのため変更後ログアウト）
  - POST /api/v1/users/change_email: メールアドレス変更（確認メール送信）

  バリデーション
  - default_servings: 1-10の範囲
  - recipe_difficulty: easy/medium/hardのいずれか
  - cooking_time: 15/30/60/999のいずれか
  - shopping_frequency: 毎日/2-3日に1回/週に1回/まとめ買いのいずれか

  エラーハンドリング
  - 401エラー: 認証エラー
  - 422エラー: バリデーションエラー（フィールドごとのエラーメッセージ）

 #### フロントエンド（Web版）

  UI構成
  - 3タブレイアウト: 基本設定/プロフィール/アカウント
  - タブごとに保存ボタンを配置
  - バリデーションエラーをフィールド下に表示
  - トースト通知による成功/エラーメッセージ

  状態管理
  - React Hooksによる状態管理
  - Promise.allによる並列データ取得
  - 関数型更新によるReact Hooks警告の回避

  エラーハンドリング
  - 401エラー時に自動ログアウト
  - 422エラー時にフィールドエラーを表示
  - その他のエラーは汎用メッセージで通知

 #### フロントエンド（LIFF版）

  UI構成
  - 1画面レイアウト（タブなし）
  - プロフィールと設定を一括保存
  - 自前のメッセージ表示（3秒後に自動消去）
  - Web版への誘導メッセージ（パスワード・メール変更）

###  編集ファイル

  Backend

  マイグレーション
  - db/migrate/YYYYMMDDHHMMSS_create_settings.rb (新規)

  モデル
  - app/models/setting.rb (新規)
  - app/models/user.rb (変更)

  コントローラー
  - app/controllers/api/v1/users/profiles_controller.rb (新規)
  - app/controllers/api/v1/users/settings_controller.rb (新規)
  - app/controllers/api/v1/users/passwords_controller.rb (新規)
  - app/controllers/api/v1/users/emails_controller.rb (新規)

  ルーティング
  - config/routes.rb (変更)

  テスト
  - spec/models/setting_spec.rb (新規)
  - spec/models/user_spec.rb (変更)
  - spec/requests/api/v1/users/profiles_spec.rb (新規)
  - spec/requests/api/v1/users/settings_spec.rb (新規)
  - spec/requests/api/v1/users/passwords_spec.rb (新規)
  - spec/requests/api/v1/users/emails_spec.rb (新規)

  その他
  - spec/factories/favorite_recipes.rb (Rubocop自動修正)
  - spec/models/favorite_recipe_spec.rb (Rubocop自動修正)
  - spec/requests/api/v1/favorite_recipes_spec.rb (Rubocop自動修正)

  Frontend (Web版)

  API
  - src/api/users.ts (新規)

  定数
  - src/constants/settings.ts (新規)

  ページ
  - src/pages/Settings/Settings.tsx (変更 - モックから実装へ)

  テスト
  - test/Settings.test.tsx (新規)

  Frontend (LIFF版)

  API
  - src/api/users.ts (新規)

  定数
  - src/constants/settings.ts (新規)

  ページ
  - src/pages/Settings/Settings.tsx (変更 - プレースホルダーから実装へ)

  テスト
  - test/Settings.test.tsx (新規)