### PR TITLE
feature/issue 50 disliked ingredient management

### DIFF
--- a/backend/app/controllers/api/v1/users/disliked_ingredients_controller.rb
+++ b/backend/app/controllers/api/v1/users/disliked_ingredients_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::Users::DislikedIngredientsController < ApplicationController
   def index
     disliked_ingredients = current_user.disliked_ingredients.includes(:ingredient).recent
     serialized_data = DislikedIngredientSerializer.new(disliked_ingredients).serializable_hash
-    render json: serialized_data[:data].map { |item| item[:attributes] }
+    render json: serialized_data[:data].map { |item| item[:attributes].merge(id: item[:id]) }
   end
 
   # POST /api/v1/users/disliked_ingredients
@@ -15,7 +15,7 @@ class Api::V1::Users::DislikedIngredientsController < ApplicationController
 
     if disliked_ingredient.save
       serialized_data = DislikedIngredientSerializer.new(disliked_ingredient).serializable_hash
-      render json: serialized_data[:data][:attributes], status: :created
+      render json: serialized_data[:data][:attributes].merge(id: serialized_data[:data][:id]), status: :created
     else
       render json: { errors: disliked_ingredient.errors.messages }, status: :unprocessable_entity
     end
@@ -31,7 +31,7 @@ class Api::V1::Users::DislikedIngredientsController < ApplicationController
   def update
     if @disliked_ingredient.update(disliked_ingredient_params)
       serialized_data = DislikedIngredientSerializer.new(@disliked_ingredient).serializable_hash
-      render json: serialized_data[:data][:attributes]
+      render json: serialized_data[:data][:attributes].merge(id: serialized_data[:data][:id])
     else
       render json: { errors: @disliked_ingredient.errors.messages }, status: :unprocessable_entity
     end

--- a/backend/app/controllers/api/v1/users/disliked_ingredients_controller.rb
+++ b/backend/app/controllers/api/v1/users/disliked_ingredients_controller.rb
@@ -1,0 +1,63 @@
+class Api::V1::Users::DislikedIngredientsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_disliked_ingredient, only: [ :update, :destroy ]
+
+  # GET /api/v1/users/disliked_ingredients
+  def index
+    disliked_ingredients = current_user.disliked_ingredients.includes(:ingredient).recent
+    serialized_data = DislikedIngredientSerializer.new(disliked_ingredients).serializable_hash
+    render json: serialized_data[:data].map { |item| item[:attributes] }
+  end
+
+  # POST /api/v1/users/disliked_ingredients
+  def create
+    disliked_ingredient = current_user.disliked_ingredients.build(disliked_ingredient_params)
+
+    if disliked_ingredient.save
+      serialized_data = DislikedIngredientSerializer.new(disliked_ingredient).serializable_hash
+      render json: serialized_data[:data][:attributes], status: :created
+    else
+      render json: { errors: disliked_ingredient.errors.messages }, status: :unprocessable_entity
+    end
+  rescue ArgumentError => e
+    if e.message.include?("is not a valid priority")
+      render json: { errors: { priority: [ e.message ] } }, status: :unprocessable_entity
+    else
+      raise
+    end
+  end
+
+  # PATCH /api/v1/users/disliked_ingredients/:id
+  def update
+    if @disliked_ingredient.update(disliked_ingredient_params)
+      serialized_data = DislikedIngredientSerializer.new(@disliked_ingredient).serializable_hash
+      render json: serialized_data[:data][:attributes]
+    else
+      render json: { errors: @disliked_ingredient.errors.messages }, status: :unprocessable_entity
+    end
+  rescue ArgumentError => e
+    if e.message.include?("is not a valid priority")
+      render json: { errors: { priority: [ e.message ] } }, status: :unprocessable_entity
+    else
+      raise
+    end
+  end
+
+  # DELETE /api/v1/users/disliked_ingredients/:id
+  def destroy
+    @disliked_ingredient.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_disliked_ingredient
+    @disliked_ingredient = current_user.disliked_ingredients.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: "苦手食材が見つかりません" }, status: :not_found
+  end
+
+  def disliked_ingredient_params
+    params.require(:disliked_ingredient).permit(:ingredient_id, :priority, :reason)
+  end
+end

--- a/backend/app/models/disliked_ingredient.rb
+++ b/backend/app/models/disliked_ingredient.rb
@@ -1,0 +1,33 @@
+class DislikedIngredient < ApplicationRecord
+  # Enums
+  enum :priority, {
+    low: 0,
+    medium: 1,
+    high: 2
+  }, prefix: :priority
+
+  # Associations
+  belongs_to :user
+  belongs_to :ingredient
+
+  # Validations
+  validates :priority, presence: true, inclusion: { in: priorities.keys }
+  validates :reason, length: { maximum: 500, message: "は500文字以内で入力してください" }, allow_blank: true
+  validates :ingredient_id, uniqueness: { scope: :user_id, message: "は既に登録されています" }
+
+  # Scopes
+  scope :by_priority, ->(priority) { where(priority: priority) }
+  scope :recent, -> { order(created_at: :desc) }
+
+  # Instance methods
+  def priority_label
+    case priority
+    when "low"
+      "低"
+    when "medium"
+      "中"
+    when "high"
+      "高"
+    end
+  end
+end

--- a/backend/app/models/ingredient.rb
+++ b/backend/app/models/ingredient.rb
@@ -17,6 +17,7 @@ class Ingredient < ApplicationRecord
   has_many :shopping_list_items, dependent: :destroy
   has_many :shopping_lists, through: :shopping_list_items
   has_many :allergy_ingredients, dependent: :destroy
+  has_many :disliked_ingredients, dependent: :destroy
 
   # Validations
   validates :name, presence: true, uniqueness: true, length: { maximum: 100 }

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -25,6 +25,8 @@ class User < ApplicationRecord
   has_many :favorited_recipes, through: :favorite_recipes, source: :recipe
   has_many :allergy_ingredients, dependent: :destroy
   has_many :allergen_ingredients, through: :allergy_ingredients, source: :ingredient
+  has_many :disliked_ingredients, dependent: :destroy
+  has_many :disliked_ingredient_ingredients, through: :disliked_ingredients, source: :ingredient
 
   # Callbacks
   after_create :build_default_setting, if: -> { setting.nil? }

--- a/backend/app/serializers/disliked_ingredient_serializer.rb
+++ b/backend/app/serializers/disliked_ingredient_serializer.rb
@@ -1,0 +1,19 @@
+class DislikedIngredientSerializer
+  include JSONAPI::Serializer
+
+  attributes :id, :user_id, :ingredient_id, :reason, :created_at, :updated_at
+
+  attribute :priority do |object|
+    object.priority
+  end
+
+  attribute :priority_label do |object|
+    object.priority_label
+  end
+
+  attribute :ingredient do |object|
+    if object.ingredient
+      IngredientSerializer.new(object.ingredient).serializable_hash[:data][:attributes]
+    end
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -75,6 +75,7 @@ Rails.application.routes.draw do
         resource :profile, only: [ :show, :update ]
         resource :settings, only: [ :show, :update ]
         resources :allergy_ingredients, only: [ :index, :create, :update, :destroy ]
+        resources :disliked_ingredients, only: [ :index, :create, :update, :destroy ]
         post "change_password", to: "passwords#create"
         post "change_email", to: "emails#create"
       end

--- a/backend/db/migrate/20251008082323_create_disliked_ingredients.rb
+++ b/backend/db/migrate/20251008082323_create_disliked_ingredients.rb
@@ -1,0 +1,16 @@
+class CreateDislikedIngredients < ActiveRecord::Migration[7.2]
+  def change
+    create_table :disliked_ingredients do |t|
+      t.references :user, null: false, foreign_key: { on_delete: :cascade }, comment: "ユーザーID"
+      t.references :ingredient, null: false, foreign_key: { on_delete: :cascade }, comment: "食材ID"
+      t.integer :priority, null: false, default: 0, comment: "優先度（0: low, 1: medium, 2: high）"
+      t.text :reason, comment: "理由"
+
+      t.timestamps
+    end
+
+    add_index :disliked_ingredients, [ :user_id, :ingredient_id ], unique: true, name: "index_disliked_ingredients_on_user_and_ingredient"
+    add_check_constraint :disliked_ingredients, "priority = ANY (ARRAY[0, 1, 2])", name: "chk_priority_valid"
+    add_check_constraint :disliked_ingredients, "char_length(reason) <= 500 OR reason IS NULL", name: "chk_reason_length"
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_07_075612) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_08_082323) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -26,6 +26,20 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_07_075612) do
     t.index ["user_id"], name: "index_allergy_ingredients_on_user_id"
     t.check_constraint "length(note) <= 500 OR note IS NULL", name: "chk_note_length"
     t.check_constraint "severity = ANY (ARRAY[0, 1, 2])", name: "chk_severity_valid"
+  end
+
+  create_table "disliked_ingredients", force: :cascade do |t|
+    t.bigint "user_id", null: false, comment: "ユーザーID"
+    t.bigint "ingredient_id", null: false, comment: "食材ID"
+    t.integer "priority", default: 0, null: false, comment: "優先度（0: low, 1: medium, 2: high）"
+    t.text "reason", comment: "理由"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["ingredient_id"], name: "index_disliked_ingredients_on_ingredient_id"
+    t.index ["user_id", "ingredient_id"], name: "index_disliked_ingredients_on_user_and_ingredient", unique: true
+    t.index ["user_id"], name: "index_disliked_ingredients_on_user_id"
+    t.check_constraint "char_length(reason) <= 500 OR reason IS NULL", name: "chk_reason_length"
+    t.check_constraint "priority = ANY (ARRAY[0, 1, 2])", name: "chk_priority_valid"
   end
 
   create_table "favorite_recipes", force: :cascade do |t|
@@ -218,6 +232,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_07_075612) do
 
   add_foreign_key "allergy_ingredients", "ingredients", on_delete: :cascade
   add_foreign_key "allergy_ingredients", "users", on_delete: :cascade
+  add_foreign_key "disliked_ingredients", "ingredients", on_delete: :cascade
+  add_foreign_key "disliked_ingredients", "users", on_delete: :cascade
   add_foreign_key "favorite_recipes", "recipes", on_delete: :cascade
   add_foreign_key "favorite_recipes", "users", on_delete: :cascade
   add_foreign_key "fridge_images", "line_accounts"

--- a/backend/spec/factories/disliked_ingredients.rb
+++ b/backend/spec/factories/disliked_ingredients.rb
@@ -1,0 +1,28 @@
+FactoryBot.define do
+  factory :disliked_ingredient do
+    association :user
+    association :ingredient
+    priority { :low }
+    reason { Faker::Lorem.sentence }
+
+    trait :low do
+      priority { :low }
+    end
+
+    trait :medium do
+      priority { :medium }
+    end
+
+    trait :high do
+      priority { :high }
+    end
+
+    trait :without_reason do
+      reason { nil }
+    end
+
+    trait :with_long_reason do
+      reason { "a" * 500 }
+    end
+  end
+end

--- a/backend/spec/models/disliked_ingredient_spec.rb
+++ b/backend/spec/models/disliked_ingredient_spec.rb
@@ -1,0 +1,123 @@
+require 'rails_helper'
+
+RSpec.describe DislikedIngredient, type: :model do
+  let(:user) { create(:user) }
+  let(:ingredient) { create(:ingredient) }
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:ingredient) }
+  end
+
+  describe 'validations' do
+    subject { build(:disliked_ingredient, user: user, ingredient: ingredient) }
+
+    it { is_expected.to validate_presence_of(:priority) }
+
+    it 'validates priority inclusion' do
+      expect(subject).to allow_value('low').for(:priority)
+      expect(subject).to allow_value('medium').for(:priority)
+      expect(subject).to allow_value('high').for(:priority)
+
+      expect {
+        build(:disliked_ingredient, user: user, ingredient: ingredient).tap do |di|
+          di.priority = 'invalid'
+        end
+      }.to raise_error(ArgumentError, "'invalid' is not a valid priority")
+    end
+
+    it 'validates reason length' do
+      disliked_ingredient = build(:disliked_ingredient, reason: 'a' * 500)
+      expect(disliked_ingredient).to be_valid
+
+      disliked_ingredient.reason = 'a' * 501
+      expect(disliked_ingredient).not_to be_valid
+      expect(disliked_ingredient.errors[:reason]).to include('は500文字以内で入力してください')
+    end
+
+    it 'allows blank reason' do
+      disliked_ingredient = build(:disliked_ingredient, reason: nil)
+      expect(disliked_ingredient).to be_valid
+
+      disliked_ingredient.reason = ''
+      expect(disliked_ingredient).to be_valid
+    end
+
+    describe 'uniqueness validation' do
+      before do
+        create(:disliked_ingredient, user: user, ingredient: ingredient)
+      end
+
+      it 'does not allow duplicate user_id and ingredient_id combination' do
+        duplicate = build(:disliked_ingredient, user: user, ingredient: ingredient)
+        expect(duplicate).not_to be_valid
+        expect(duplicate.errors[:ingredient_id]).to include('は既に登録されています')
+      end
+
+      it 'allows same ingredient for different users' do
+        another_user = create(:user, email: 'another@example.com')
+        disliked_ingredient = build(:disliked_ingredient, user: another_user, ingredient: ingredient)
+        expect(disliked_ingredient).to be_valid
+      end
+
+      it 'allows same user with different ingredients' do
+        another_ingredient = create(:ingredient, name: 'セロリ')
+        disliked_ingredient = build(:disliked_ingredient, user: user, ingredient: another_ingredient)
+        expect(disliked_ingredient).to be_valid
+      end
+    end
+  end
+
+  describe 'enums' do
+    it 'defines priority enum correctly' do
+      disliked_ingredient = create(:disliked_ingredient, priority: :low)
+      expect(disliked_ingredient.priority).to eq('low')
+      expect(disliked_ingredient.priority_low?).to be true
+      expect(disliked_ingredient.priority_medium?).to be false
+      expect(disliked_ingredient.priority_high?).to be false
+    end
+
+    it 'has correct priority values' do
+      expect(DislikedIngredient.priorities).to eq({ 'low' => 0, 'medium' => 1, 'high' => 2 })
+    end
+  end
+
+  describe 'scopes' do
+    let!(:low_disliked) { create(:disliked_ingredient, user: user, priority: :low) }
+    let!(:medium_disliked) { create(:disliked_ingredient, user: user, priority: :medium, ingredient: create(:ingredient, name: 'セロリ')) }
+    let!(:high_disliked) { create(:disliked_ingredient, user: user, priority: :high, ingredient: create(:ingredient, name: 'パクチー')) }
+
+    describe '.by_priority' do
+      it 'filters by priority' do
+        low_results = DislikedIngredient.by_priority(:low)
+        expect(low_results).to include(low_disliked)
+        expect(low_results).not_to include(medium_disliked, high_disliked)
+      end
+    end
+
+    describe '.recent' do
+      it 'orders by created_at desc' do
+        results = DislikedIngredient.recent
+        expect(results.first).to eq(high_disliked)
+        expect(results.last).to eq(low_disliked)
+      end
+    end
+  end
+
+  describe '#priority_label' do
+    it 'returns correct label for low' do
+      disliked_ingredient = build(:disliked_ingredient, priority: :low)
+      expect(disliked_ingredient.priority_label).to eq('低')
+    end
+
+    it 'returns correct label for medium' do
+      disliked_ingredient = build(:disliked_ingredient, priority: :medium)
+      expect(disliked_ingredient.priority_label).to eq('中')
+    end
+
+    it 'returns correct label for high' do
+      disliked_ingredient = build(:disliked_ingredient, priority: :high)
+      expect(disliked_ingredient.priority_label).to eq('高')
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/users/disliked_ingredients_spec.rb
+++ b/backend/spec/requests/api/v1/users/disliked_ingredients_spec.rb
@@ -1,0 +1,250 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Users::DislikedIngredients", type: :request do
+  let(:user) { create(:user, :confirmed) }
+  let(:other_user) { create(:user, :confirmed, email: "other@example.com") }
+  let(:ingredient) { create(:ingredient, name: "セロリ") }
+  let(:cilantro_ingredient) { create(:ingredient, name: "パクチー") }
+
+  def auth_header_for(user)
+    post "/api/v1/auth/login", params: { user: { email: user.email, password: "password123" } }, as: :json
+    { "Authorization" => response.headers["Authorization"] }
+  end
+
+  describe "GET /api/v1/users/disliked_ingredients" do
+    let!(:disliked1) { create(:disliked_ingredient, user: user, ingredient: ingredient, priority: :low) }
+    let!(:disliked2) { create(:disliked_ingredient, user: user, ingredient: cilantro_ingredient, priority: :high) }
+    let!(:other_disliked) { create(:disliked_ingredient, user: other_user, ingredient: ingredient) }
+
+    it "認証なしで401を返す" do
+      get "/api/v1/users/disliked_ingredients", as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "認証済みユーザーの苦手食材一覧を返す" do
+      headers = auth_header_for(user)
+      get "/api/v1/users/disliked_ingredients", headers: headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body.size).to eq(2)
+
+      # 最新順で返される
+      expect(body.first["ingredient_id"]).to eq(cilantro_ingredient.id)
+      expect(body.first["priority"]).to eq("high")
+      expect(body.first["priority_label"]).to eq("高")
+      expect(body.first["ingredient"]["name"]).to eq("パクチー")
+
+      expect(body.last["ingredient_id"]).to eq(ingredient.id)
+      expect(body.last["priority"]).to eq("low")
+      expect(body.last["priority_label"]).to eq("低")
+    end
+
+    it "他のユーザーの苦手食材は返さない" do
+      headers = auth_header_for(user)
+      get "/api/v1/users/disliked_ingredients", headers: headers, as: :json
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      user_ids = body.map { |item| item["user_id"] }.uniq
+      expect(user_ids).to eq([ user.id ])
+      expect(user_ids).not_to include(other_user.id)
+    end
+  end
+
+  describe "POST /api/v1/users/disliked_ingredients" do
+    let(:valid_params) do
+      {
+        disliked_ingredient: {
+          ingredient_id: ingredient.id,
+          priority: "medium",
+          reason: "苦味が強くて食べられない"
+        }
+      }
+    end
+
+    it "認証なしで401を返す" do
+      post "/api/v1/users/disliked_ingredients", params: valid_params, as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "有効なパラメータで苦手食材を登録する" do
+      headers = auth_header_for(user)
+
+      expect {
+        post "/api/v1/users/disliked_ingredients", params: valid_params, headers: headers, as: :json
+      }.to change(DislikedIngredient, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      body = JSON.parse(response.body)
+      expect(body["user_id"]).to eq(user.id)
+      expect(body["ingredient_id"]).to eq(ingredient.id)
+      expect(body["priority"]).to eq("medium")
+      expect(body["priority_label"]).to eq("中")
+      expect(body["reason"]).to eq("苦味が強くて食べられない")
+      expect(body["ingredient"]["name"]).to eq("セロリ")
+    end
+
+    it "reasonなしでも登録できる" do
+      headers = auth_header_for(user)
+      params = { disliked_ingredient: { ingredient_id: ingredient.id, priority: "low" } }
+
+      post "/api/v1/users/disliked_ingredients", params: params, headers: headers, as: :json
+      expect(response).to have_http_status(:created)
+      body = JSON.parse(response.body)
+      expect(body["reason"]).to be_nil
+    end
+
+    it "同じ食材の重複登録時に422を返す" do
+      create(:disliked_ingredient, user: user, ingredient: ingredient)
+      headers = auth_header_for(user)
+
+      post "/api/v1/users/disliked_ingredients", params: valid_params, headers: headers, as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+      body = JSON.parse(response.body)
+      expect(body["errors"]["ingredient_id"]).to include("は既に登録されています")
+    end
+
+    it "無効なpriorityで422を返す" do
+      headers = auth_header_for(user)
+      invalid_params = { disliked_ingredient: { ingredient_id: ingredient.id, priority: "invalid" } }
+
+      expect {
+        post "/api/v1/users/disliked_ingredients", params: invalid_params, headers: headers, as: :json
+      }.not_to raise_error
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      body = JSON.parse(response.body)
+      expect(body["errors"]["priority"]).to be_present
+      expect(body["errors"]["priority"].first).to include("invalid")
+    end
+
+    it "reasonが501文字以上で422を返す" do
+      headers = auth_header_for(user)
+      invalid_params = {
+        disliked_ingredient: {
+          ingredient_id: ingredient.id,
+          priority: "low",
+          reason: "a" * 501
+        }
+      }
+
+      post "/api/v1/users/disliked_ingredients", params: invalid_params, headers: headers, as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+      body = JSON.parse(response.body)
+      expect(body["errors"]["reason"]).to include("は500文字以内で入力してください")
+    end
+  end
+
+  describe "PATCH /api/v1/users/disliked_ingredients/:id" do
+    let!(:disliked_ingredient) { create(:disliked_ingredient, user: user, ingredient: ingredient, priority: :low, reason: "元のメモ") }
+    let(:update_params) do
+      {
+        disliked_ingredient: {
+          priority: "high",
+          reason: "更新されたメモ"
+        }
+      }
+    end
+
+    it "認証なしで401を返す" do
+      patch "/api/v1/users/disliked_ingredients/#{disliked_ingredient.id}", params: update_params, as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "有効なパラメータで苦手食材を更新する" do
+      headers = auth_header_for(user)
+
+      patch "/api/v1/users/disliked_ingredients/#{disliked_ingredient.id}", params: update_params, headers: headers, as: :json
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["priority"]).to eq("high")
+      expect(body["priority_label"]).to eq("高")
+      expect(body["reason"]).to eq("更新されたメモ")
+
+      disliked_ingredient.reload
+      expect(disliked_ingredient.priority).to eq("high")
+      expect(disliked_ingredient.reason).to eq("更新されたメモ")
+    end
+
+    it "他のユーザーの苦手食材を更新しようとすると404を返す" do
+      other_disliked = create(:disliked_ingredient, user: other_user, ingredient: cilantro_ingredient)
+      headers = auth_header_for(user)
+
+      patch "/api/v1/users/disliked_ingredients/#{other_disliked.id}", params: update_params, headers: headers, as: :json
+      expect(response).to have_http_status(:not_found)
+      body = JSON.parse(response.body)
+      expect(body["error"]).to eq("苦手食材が見つかりません")
+    end
+
+    it "存在しないIDで404を返す" do
+      headers = auth_header_for(user)
+
+      patch "/api/v1/users/disliked_ingredients/99999", params: update_params, headers: headers, as: :json
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "reasonが501文字以上で422を返す" do
+      headers = auth_header_for(user)
+      invalid_params = { disliked_ingredient: { reason: "a" * 501 } }
+
+      patch "/api/v1/users/disliked_ingredients/#{disliked_ingredient.id}", params: invalid_params, headers: headers, as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+      body = JSON.parse(response.body)
+      expect(body["errors"]["reason"]).to include("は500文字以内で入力してください")
+    end
+
+    it "無効なpriorityで422を返す" do
+      headers = auth_header_for(user)
+      invalid_params = { disliked_ingredient: { priority: "invalid" } }
+
+      expect {
+        patch "/api/v1/users/disliked_ingredients/#{disliked_ingredient.id}", params: invalid_params, headers: headers, as: :json
+      }.not_to raise_error
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      body = JSON.parse(response.body)
+      expect(body["errors"]["priority"]).to be_present
+      expect(body["errors"]["priority"].first).to include("invalid")
+    end
+  end
+
+  describe "DELETE /api/v1/users/disliked_ingredients/:id" do
+    let!(:disliked_ingredient) { create(:disliked_ingredient, user: user, ingredient: ingredient) }
+
+    it "認証なしで401を返す" do
+      delete "/api/v1/users/disliked_ingredients/#{disliked_ingredient.id}", as: :json
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "苦手食材を削除する" do
+      headers = auth_header_for(user)
+
+      expect {
+        delete "/api/v1/users/disliked_ingredients/#{disliked_ingredient.id}", headers: headers, as: :json
+      }.to change(DislikedIngredient, :count).by(-1)
+
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it "他のユーザーの苦手食材を削除しようとすると404を返す" do
+      other_disliked = create(:disliked_ingredient, user: other_user, ingredient: cilantro_ingredient)
+      headers = auth_header_for(user)
+
+      expect {
+        delete "/api/v1/users/disliked_ingredients/#{other_disliked.id}", headers: headers, as: :json
+      }.not_to change(DislikedIngredient, :count)
+
+      expect(response).to have_http_status(:not_found)
+      body = JSON.parse(response.body)
+      expect(body["error"]).to eq("苦手食材が見つかりません")
+    end
+
+    it "存在しないIDで404を返す" do
+      headers = auth_header_for(user)
+
+      delete "/api/v1/users/disliked_ingredients/99999", headers: headers, as: :json
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/users/disliked_ingredients_spec.rb
+++ b/backend/spec/requests/api/v1/users/disliked_ingredients_spec.rb
@@ -30,11 +30,13 @@ RSpec.describe "Api::V1::Users::DislikedIngredients", type: :request do
       expect(body.size).to eq(2)
 
       # 最新順で返される
+      expect(body.first["id"]).to eq(disliked2.id.to_s)
       expect(body.first["ingredient_id"]).to eq(cilantro_ingredient.id)
       expect(body.first["priority"]).to eq("high")
       expect(body.first["priority_label"]).to eq("高")
       expect(body.first["ingredient"]["name"]).to eq("パクチー")
 
+      expect(body.last["id"]).to eq(disliked1.id.to_s)
       expect(body.last["ingredient_id"]).to eq(ingredient.id)
       expect(body.last["priority"]).to eq("low")
       expect(body.last["priority_label"]).to eq("低")
@@ -77,6 +79,7 @@ RSpec.describe "Api::V1::Users::DislikedIngredients", type: :request do
 
       expect(response).to have_http_status(:created)
       body = JSON.parse(response.body)
+      expect(body["id"]).to be_present
       expect(body["user_id"]).to eq(user.id)
       expect(body["ingredient_id"]).to eq(ingredient.id)
       expect(body["priority"]).to eq("medium")
@@ -158,6 +161,7 @@ RSpec.describe "Api::V1::Users::DislikedIngredients", type: :request do
       patch "/api/v1/users/disliked_ingredients/#{disliked_ingredient.id}", params: update_params, headers: headers, as: :json
       expect(response).to have_http_status(:ok)
       body = JSON.parse(response.body)
+      expect(body["id"]).to eq(disliked_ingredient.id.to_s)
       expect(body["priority"]).to eq("high")
       expect(body["priority_label"]).to eq("高")
       expect(body["reason"]).to eq("更新されたメモ")


### PR DESCRIPTION
## 概要

  Issue #48のAllergyIngredient実装と同様の設計思想で、ユーザーの苦手な食材を管理する機能を実装した。

  ## 実装内容

  ### データベース設計
  - **マイグレーション**: `20251008082323_create_disliked_ingredients.rb`
    - `user_id`: references, null: false, foreign_key (on_delete: cascade)
    - `ingredient_id`: references, null: false, foreign_key (on_delete: cascade)
    - `priority`: integer, null: false, default: 0 (0: low, 1: medium, 2: high)
    - `reason`: text (最大500文字、NULL許可)
    - ユニークインデックス: `[user_id, ingredient_id]`
    - CHECK制約: `priority IN (0, 1, 2)`
    - CHECK制約: `char_length(reason) <= 500` (マルチバイト対応)

  ### モデル実装
  - **DislikedIngredient** (`app/models/disliked_ingredient.rb`)
    - enum :priority (low: 0, medium: 1, high: 2)
    - belongs_to :user, :ingredient
    - バリデーション: priority (presence, inclusion), reason (length), ingredient_id (uniqueness)
    - スコープ: by_priority, recent
    - インスタンスメソッド: priority_label (固定文字列で日本語ラベル返却)

  - **関連モデルへの追加**
    - User: `has_many :disliked_ingredients`, `has_many :disliked_ingredient_ingredients, through:
  :disliked_ingredients, source: :ingredient`
    - Ingredient: `has_many :disliked_ingredients`

  ### シリアライザ実装
  - **DislikedIngredientSerializer** (`app/serializers/disliked_ingredient_serializer.rb`)
    - attributes: id, user_id, ingredient_id, priority, priority_label, reason, created_at, updated_at
    - ingredient情報をネストして返却

  ### API実装
  - **Api::V1::Users::DislikedIngredientsController**
    - `GET /api/v1/users/disliked_ingredients` - 一覧取得 (includes(:ingredient)でN+1対策)
    - `POST /api/v1/users/disliked_ingredients` - 登録
    - `PATCH /api/v1/users/disliked_ingredients/:id` - 更新
    - `DELETE /api/v1/users/disliked_ingredients/:id` - 削除
    - 認証・認可: before_action :authenticate_user!, current_userスコープ
    - ArgumentError (enum不正値) を限定的にハンドリングして422で返却
    - レスポンスにidをマージして返却

  ### ルーティング
  - `config/routes.rb`のusersネームスペースに追加
    - `resources :disliked_ingredients, only: [:index, :create, :update, :destroy]`

  ## 編集ファイル

  ### 新規作成
  - `backend/db/migrate/20251008082323_create_disliked_ingredients.rb`
  - `backend/app/models/disliked_ingredient.rb`
  - `backend/app/serializers/disliked_ingredient_serializer.rb`
  - `backend/app/controllers/api/v1/users/disliked_ingredients_controller.rb`
  - `backend/spec/models/disliked_ingredient_spec.rb`
  - `backend/spec/requests/api/v1/users/disliked_ingredients_spec.rb`
  - `backend/spec/factories/disliked_ingredients.rb`

  ### 変更
  - `backend/app/models/user.rb` - disliked_ingredients関連を追加
  - `backend/app/models/ingredient.rb` - disliked_ingredients関連を追加
  - `backend/config/routes.rb` - disliked_ingredientsルートを追加
  - `backend/db/schema.rb` - マイグレーション実行により自動更新