### PR TITLE
LIFFの画像認識機能修正

### DIFF
--- a/liff/src/api/imageRecognition.ts
+++ b/liff/src/api/imageRecognition.ts
@@ -1,0 +1,55 @@
+import { apiClient } from './client'
+
+export interface ImageRecognitionResponse {
+  success: boolean
+  recognized_ingredients: Array<{
+    name: string
+    confidence: number
+  }>
+  message?: string
+  errors?: string[]
+}
+
+const sendRecognitionRequest = async (formData: FormData): Promise<ImageRecognitionResponse> => {
+  const response = await apiClient.post<ImageRecognitionResponse>(
+    '/user_ingredients/recognize',
+    formData,
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    }
+  )
+
+  return response.data
+}
+
+export const imageRecognitionApi = {
+  /**
+   * 単一画像で食材認識を実行する
+   */
+  async recognizeIngredients(image: File): Promise<ImageRecognitionResponse> {
+    const formData = new FormData()
+    formData.append('image', image)
+    return sendRecognitionRequest(formData)
+  },
+
+  /**
+   * 複数画像で食材認識を実行する
+   */
+  async recognizeMultipleIngredients(images: File[]): Promise<ImageRecognitionResponse> {
+    const formData = new FormData()
+
+    if (images.length === 1) {
+      formData.append('image', images[0])
+    } else {
+      images.forEach((image) => {
+        formData.append('images[]', image)
+      })
+    }
+
+    return sendRecognitionRequest(formData)
+  },
+}
+
+export default imageRecognitionApi

--- a/liff/test/imageRecognition.test.ts
+++ b/liff/test/imageRecognition.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { imageRecognitionApi } from '../src/api/imageRecognition'
+import { apiClient } from '../src/api/client'
+
+vi.mock('../src/api/client', () => ({
+  apiClient: {
+    post: vi.fn(),
+  },
+}))
+
+describe('imageRecognitionApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('recognizeIngredients', () => {
+    it('単一画像で食材認識APIを呼び出す', async () => {
+      const mockFile = new File(['test'], 'test.jpg', { type: 'image/jpeg' })
+      const mockResponse = {
+        success: true,
+        recognized_ingredients: [
+          { name: 'トマト', confidence: 0.95 },
+          { name: 'きゅうり', confidence: 0.88 },
+        ],
+      }
+
+      vi.mocked(apiClient.post).mockResolvedValueOnce({ data: mockResponse })
+
+      const result = await imageRecognitionApi.recognizeIngredients(mockFile)
+
+      expect(apiClient.post).toHaveBeenCalledTimes(1)
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/user_ingredients/recognize',
+        expect.any(FormData),
+        {
+          headers: {
+            'Content-Type': 'multipart/form-data',
+          },
+        }
+      )
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('FormDataに画像が正しく追加される', async () => {
+      const mockFile = new File(['test'], 'test.jpg', { type: 'image/jpeg' })
+      const mockResponse = {
+        success: true,
+        recognized_ingredients: [],
+      }
+
+      let capturedFormData: FormData | undefined
+
+      vi.mocked(apiClient.post).mockImplementationOnce((url, data) => {
+        capturedFormData = data as FormData
+        return Promise.resolve({ data: mockResponse })
+      })
+
+      await imageRecognitionApi.recognizeIngredients(mockFile)
+
+      expect(capturedFormData).toBeInstanceOf(FormData)
+      expect(capturedFormData?.get('image')).toBe(mockFile)
+    })
+
+    it('API呼び出しエラー時にエラーを投げる', async () => {
+      const mockFile = new File(['test'], 'test.jpg', { type: 'image/jpeg' })
+      const mockError = new Error('Network error')
+
+      vi.mocked(apiClient.post).mockRejectedValueOnce(mockError)
+
+      await expect(imageRecognitionApi.recognizeIngredients(mockFile)).rejects.toThrow('Network error')
+    })
+  })
+
+  describe('recognizeMultipleIngredients', () => {
+    it('単一画像の場合はimageキーで送信', async () => {
+      const mockFile = new File(['test'], 'test.jpg', { type: 'image/jpeg' })
+      const mockResponse = {
+        success: true,
+        recognized_ingredients: [{ name: 'にんじん', confidence: 0.92 }],
+      }
+
+      let capturedFormData: FormData | undefined
+
+      vi.mocked(apiClient.post).mockImplementationOnce((url, data) => {
+        capturedFormData = data as FormData
+        return Promise.resolve({ data: mockResponse })
+      })
+
+      await imageRecognitionApi.recognizeMultipleIngredients([mockFile])
+
+      expect(capturedFormData).toBeInstanceOf(FormData)
+      expect(capturedFormData?.get('image')).toBe(mockFile)
+      expect(capturedFormData?.has('images[]')).toBe(false)
+    })
+
+    it('複数画像の場合はimages[]キーで送信', async () => {
+      const mockFile1 = new File(['test1'], 'test1.jpg', { type: 'image/jpeg' })
+      const mockFile2 = new File(['test2'], 'test2.jpg', { type: 'image/jpeg' })
+      const mockResponse = {
+        success: true,
+        recognized_ingredients: [
+          { name: 'キャベツ', confidence: 0.89 },
+          { name: 'レタス', confidence: 0.85 },
+        ],
+      }
+
+      vi.mocked(apiClient.post).mockResolvedValueOnce({ data: mockResponse })
+
+      const result = await imageRecognitionApi.recognizeMultipleIngredients([mockFile1, mockFile2])
+
+      expect(apiClient.post).toHaveBeenCalledTimes(1)
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('APIからエラーレスポンスが返る場合', async () => {
+      const mockFile = new File(['test'], 'test.jpg', { type: 'image/jpeg' })
+      const mockResponse = {
+        success: false,
+        recognized_ingredients: [],
+        message: '画像の認識に失敗しました',
+        errors: ['ファイルサイズが大きすぎます'],
+      }
+
+      vi.mocked(apiClient.post).mockResolvedValueOnce({ data: mockResponse })
+
+      const result = await imageRecognitionApi.recognizeMultipleIngredients([mockFile])
+
+      expect(result.success).toBe(false)
+      expect(result.message).toBe('画像の認識に失敗しました')
+      expect(result.errors).toEqual(['ファイルサイズが大きすぎます'])
+    })
+  })
+})

--- a/liff/test/setup.ts
+++ b/liff/test/setup.ts
@@ -174,3 +174,54 @@ if (!(document as {execCommand?: unknown}).execCommand) {
   // @ts-expect-error - documentへのexecCommand追加（非推奨だが互換性のため）
   ;(document as {execCommand?: unknown}).execCommand = vi.fn().mockReturnValue(true)
 }
+
+// FormDataのモック（画像認識API用）
+if (typeof global.FormData === 'undefined') {
+  global.FormData = class FormData {
+    private data: Map<string, unknown> = new Map()
+
+    append(key: string, value: unknown) {
+      this.data.set(key, value)
+    }
+
+    get(key: string) {
+      return this.data.get(key)
+    }
+
+    has(key: string) {
+      return this.data.has(key)
+    }
+
+    delete(key: string) {
+      this.data.delete(key)
+    }
+  } as unknown as typeof FormData
+}
+
+// Fileのモック（画像認識API用）
+if (typeof global.File === 'undefined') {
+  global.File = class File {
+    name: string
+    size: number
+    type: string
+
+    constructor(bits: BlobPart[], filename: string, options?: FilePropertyBag) {
+      this.name = filename
+      this.size = bits.reduce((acc, bit) => acc + (typeof bit === 'string' ? bit.length : 0), 0)
+      this.type = options?.type || ''
+    }
+  } as unknown as typeof File
+}
+
+// Blobのモック（画像認識API用）
+if (typeof global.Blob === 'undefined') {
+  global.Blob = class Blob {
+    size: number
+    type: string
+
+    constructor(parts?: BlobPart[], options?: BlobPropertyBag) {
+      this.size = parts?.reduce((acc, part) => acc + (typeof part === 'string' ? part.length : 0), 0) || 0
+      this.type = options?.type || ''
+    }
+  } as unknown as typeof Blob
+}


### PR DESCRIPTION
## 概要
 Issue #176 LIFF版（LINE Front-end Framework版）に画像認識機能を実装した。

  ## 実装内容

  ### APIラッパーの追加
  - ファイル: liff/src/api/imageRecognition.ts（新規作成）
  - 単一画像認識機能（recognizeIngredients）を実装
  - 複数画像認識機能（recognizeMultipleIngredients）を実装
  - 既存のapiClientを使用し、JWT認証を自動適用
  - FormDataでmultipart/form-data形式のリクエストを送信

  ### UI実装
  - ファイル: liff/src/pages/Ingredients/Ingredients.tsx（拡張）
  - 画像認識セクションを追加
    - 写真選択ボタン（カメラアイコン付き）
    - input[type="file"]による画像選択機能
    - capture="environment"属性で背面カメラを優先
    - multiple属性で複数画像選択をサポート
  - LIFF環境チェックによる文言の出し分け
    - liff.isInClient()でLINEアプリ内かを判定
    - アプリ内の場合は「カメラ起動」、ブラウザの場合は「写真を選択」と表示
  - ファイルサイズチェック（20MB制限）をクライアント側で実装
  - アップロード状態の表示（ローディング表示）
  - 認識結果のメッセージ表示
  - 認識成功後に在庫リストを自動更新

  ### テスト環境の準備
  - ファイル: liff/test/setup.ts（編集）
  - FormData、File、Blobのグローバルモックを追加
  - Vitestでの画像アップロードテストを可能に

  ### テストコードの追加
  - ファイル: liff/test/imageRecognition.test.ts（新規作成）
    - APIラッパーのユニットテスト（6ケース）
    - 単一画像認識、複数画像認識のテスト
    - エラーハンドリングの検証
    - FormDataの正しい構築を確認
  - ファイル: liff/test/Ingredients.test.tsx（拡張）
    - 画像認識機能の結合テスト（9ケース）
    - LIFF環境による文言出し分けのテスト
    - ファイル選択からアップロード、結果表示までの一連のフロー検証
    - エラーケースの網羅的テスト

  ## 編集ファイル

  ### 新規作成
  - liff/src/api/imageRecognition.ts
  - liff/test/imageRecognition.test.ts
  - .claude/issue-176-liff-image-recognition.md

  ### 編集
  - liff/src/pages/Ingredients/Ingredients.tsx
  - liff/test/setup.ts
  - liff/test/Ingredients.test.tsx